### PR TITLE
Add DB helper scripts for atomic database updates

### DIFF
--- a/.claude/hooks/read-db.py
+++ b/.claude/hooks/read-db.py
@@ -9,8 +9,9 @@ Usage:
 Exit codes: 0=success, 1=partial (some files missing), 2=critical error
 """
 import json
+import re
 import sys
-from datetime import datetime
+from datetime import datetime, timedelta
 from pathlib import Path
 
 DATA_DIR = Path("data")
@@ -32,55 +33,66 @@ def load_json(path: Path):
         return json.load(f)
 
 
+def next_session_id(sessions: list) -> str:
+    """Produce 'session-NNN' matching existing id convention.
+    Falls back to 'session-001' on empty log or unparseable last id."""
+    if not sessions:
+        return "session-001"
+    last_id = sessions[-1].get("session_id", "")
+    m = re.search(r'(\d+)', last_id)
+    if m:
+        return f"session-{int(m.group(1)) + 1:03d}"
+    return f"session-{len(sessions) + 1:03d}"
+
+
 def main():
-    result = {}
+    databases = {}
     missing = []
 
     for key, path in FILES.items():
         data = load_json(path)
         if data is None:
             missing.append(str(path))
-            result[key] = {}
+            databases[key] = {}
         else:
-            result[key] = data
+            databases[key] = data
 
-    # Computed fields
-    today = datetime.now().strftime("%Y-%m-%d")
-    yesterday = (datetime.now() - __import__('datetime').timedelta(days=1)).strftime("%Y-%m-%d")
+    now = datetime.now()
+    today = now.strftime("%Y-%m-%d")
+    yesterday = (now - timedelta(days=1)).strftime("%Y-%m-%d")
 
-    sr = result.get("spaced_repetition", {})
+    sr = databases.get("spaced_repetition", {})
     items = sr.get("items", {})
     due_items = [iid for iid, item in items.items() if item.get("due_date", "") <= today]
 
-    log = result.get("session_log", {})
+    log = databases.get("session_log", {})
     sessions = log.get("sessions", [])
-    if sessions:
-        last_id = sessions[-1].get("session_id", "000")
-        try:
-            next_id = str(int(last_id) + 1).zfill(3)
-        except ValueError:
-            next_id = f"{len(sessions) + 1:03d}"
-    else:
-        next_id = "001"
 
-    profile = result.get("learner_profile", {})
+    profile = databases.get("learner_profile", {})
     last_updated = profile.get("last_updated", "")
     streak_active = last_updated in (today, yesterday)
+    try:
+        days_since = (now - datetime.strptime(last_updated, "%Y-%m-%d")).days if last_updated else None
+    except ValueError:
+        days_since = None
 
-    result["computed"] = {
-        "today": today,
-        "due_reviews_count": len(due_items),
-        "due_review_items": due_items,
-        "next_session_id": next_id,
-        "streak_active": streak_active,
-        "days_since_last_session": (datetime.now() - datetime.strptime(last_updated, "%Y-%m-%d")).days if last_updated else None,
+    result = {
+        "databases": databases,
+        "computed": {
+            "today": today,
+            "due_reviews_count": len(due_items),
+            "due_review_items": due_items,
+            "next_session_id": next_session_id(sessions),
+            "streak_active": streak_active,
+            "days_since_last_session": days_since,
+        },
     }
 
     if missing:
         result["_warnings"] = [f"Missing file: {m}" for m in missing]
 
     json.dump(result, sys.stdout, indent=2, ensure_ascii=False)
-    print()  # trailing newline
+    print()
 
     sys.exit(1 if missing else 0)
 

--- a/.claude/hooks/read-db.py
+++ b/.claude/hooks/read-db.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""
+Fluent DB Reader Script
+Loads all 6 learning databases and outputs a single JSON object to stdout.
+
+Usage:
+    python3 .claude/hooks/read-db.py
+
+Exit codes: 0=success, 1=partial (some files missing), 2=critical error
+"""
+import json
+import sys
+from datetime import datetime
+from pathlib import Path
+
+DATA_DIR = Path("data")
+
+FILES = {
+    "learner_profile": DATA_DIR / "learner-profile.json",
+    "progress_db": DATA_DIR / "progress-db.json",
+    "mistakes_db": DATA_DIR / "mistakes-db.json",
+    "mastery_db": DATA_DIR / "mastery-db.json",
+    "spaced_repetition": DATA_DIR / "spaced-repetition.json",
+    "session_log": DATA_DIR / "session-log.json",
+}
+
+
+def load_json(path: Path):
+    if not path.exists():
+        return None
+    with open(path, 'r', encoding='utf-8') as f:
+        return json.load(f)
+
+
+def main():
+    result = {}
+    missing = []
+
+    for key, path in FILES.items():
+        data = load_json(path)
+        if data is None:
+            missing.append(str(path))
+            result[key] = {}
+        else:
+            result[key] = data
+
+    # Computed fields
+    today = datetime.now().strftime("%Y-%m-%d")
+    yesterday = (datetime.now() - __import__('datetime').timedelta(days=1)).strftime("%Y-%m-%d")
+
+    sr = result.get("spaced_repetition", {})
+    items = sr.get("items", {})
+    due_items = [iid for iid, item in items.items() if item.get("due_date", "") <= today]
+
+    log = result.get("session_log", {})
+    sessions = log.get("sessions", [])
+    if sessions:
+        last_id = sessions[-1].get("session_id", "000")
+        try:
+            next_id = str(int(last_id) + 1).zfill(3)
+        except ValueError:
+            next_id = f"{len(sessions) + 1:03d}"
+    else:
+        next_id = "001"
+
+    profile = result.get("learner_profile", {})
+    last_updated = profile.get("last_updated", "")
+    streak_active = last_updated in (today, yesterday)
+
+    result["computed"] = {
+        "today": today,
+        "due_reviews_count": len(due_items),
+        "due_review_items": due_items,
+        "next_session_id": next_id,
+        "streak_active": streak_active,
+        "days_since_last_session": (datetime.now() - datetime.strptime(last_updated, "%Y-%m-%d")).days if last_updated else None,
+    }
+
+    if missing:
+        result["_warnings"] = [f"Missing file: {m}" for m in missing]
+
+    json.dump(result, sys.stdout, indent=2, ensure_ascii=False)
+    print()  # trailing newline
+
+    sys.exit(1 if missing else 0)
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/hooks/session-end.py
+++ b/.claude/hooks/session-end.py
@@ -43,9 +43,8 @@ def main():
             with open(profile_path, 'r') as f:
                 profile = json.load(f)
 
-            stats = profile.get("stats", {})
-            streak = stats.get("streak_days", 0)
-            total_sessions = stats.get("total_practice_sessions", 0)
+            streak = profile.get("current_streak_days", 0)
+            total_sessions = profile.get("total_sessions", 0)
 
             print(f"[Fluent] 🔥 Current streak: {streak} days")
             print(f"[Fluent] 📊 Total sessions: {total_sessions}")

--- a/.claude/hooks/session-start.py
+++ b/.claude/hooks/session-start.py
@@ -30,13 +30,12 @@ def main():
             profile = json.load(f)
 
         learner = profile.get("learner", {})
-        stats = profile.get("stats", {})
 
         name = learner.get("name", "Learner")
         target_lang = learner.get("target_language", "your target language")
         current_level = learner.get("current_level", "...")
         target_level = learner.get("target_level", "...")
-        streak = stats.get("streak_days", 0)
+        streak = profile.get("current_streak_days", 0)
 
         print(f"[Fluent] 🌍 Welcome back, {name}!")
         print(f"[Fluent] 📚 Learning: {target_lang}")
@@ -53,8 +52,12 @@ def main():
                 today = datetime.now().strftime("%Y-%m-%d")
                 due_count = 0
 
-                for item in sr_data.get("items", []):
-                    if item.get("next_review_date", "") <= today:
+                items = sr_data.get("items", {})
+                # items may be a dict (current schema) or list (legacy)
+                iterable = items.values() if isinstance(items, dict) else items
+                for item in iterable:
+                    due = item.get("due_date") or item.get("next_review_date", "")
+                    if due and due <= today:
                         due_count += 1
 
                 if due_count > 0:

--- a/.claude/hooks/update-db.py
+++ b/.claude/hooks/update-db.py
@@ -5,15 +5,19 @@ Updates all 6 learning databases from a single JSON session report via stdin.
 
 Usage:
     python3 .claude/hooks/update-db.py <<'EOF'
-    { "session_id": "002", "date": "2026-04-02", ... }
+    { "session_id": "session-005", "date": "2026-04-24", ... }
     EOF
+
+See docs/DB_SCRIPTS.md for the full input schema.
 
 Exit codes: 0=success, 1=validation error, 2=blocking/data error
 """
+import copy
 import json
-import sys
 import os
+import re
 import shutil
+import sys
 from datetime import datetime, timedelta
 from pathlib import Path
 
@@ -37,12 +41,12 @@ def save_json(path: Path, data: dict):
     os.rename(str(tmp_path), str(path))
 
 
-def date_str(d: datetime) -> str:
-    return d.strftime("%Y-%m-%d")
-
-
 def parse_date(s: str) -> datetime:
     return datetime.strptime(s, "%Y-%m-%d")
+
+
+def date_str(d: datetime) -> str:
+    return d.strftime("%Y-%m-%d")
 
 
 def tomorrow(today_str: str) -> str:
@@ -73,6 +77,8 @@ def backup_all(tag: str):
 # --- SM-2 Algorithm ---
 
 def calculate_sm2(item: dict, quality: int) -> dict:
+    """Classic SM-2. Uses ceil() for interval growth (standard)."""
+    import math
     ef = item.get("easiness_factor", 2.5)
     interval = item.get("interval_days", 1)
     reps = item.get("repetitions", 0)
@@ -83,7 +89,7 @@ def calculate_sm2(item: dict, quality: int) -> dict:
         elif reps == 1:
             interval = 6
         else:
-            interval = round(interval * ef)
+            interval = int(math.ceil(interval * ef))
         reps += 1
     else:
         reps = 0
@@ -100,14 +106,22 @@ def calculate_sm2(item: dict, quality: int) -> dict:
 
 
 # --- Updater functions ---
+# Each mutates in place. Confidence in learner-profile is 0-100 int.
+# Session-log preserves the existing rich schema (skills_practiced array,
+# score_breakdown, topics_covered, breakthroughs, focus_next_session,
+# achievements_earned). Spaced-repetition preserves consecutive_*,
+# mastery_level, total_reviews, priority, content, answer, category,
+# difficulty fields on existing items.
 
 def update_learner_profile(profile: dict, session: dict):
     today = session["date"]
     last = profile.get("last_updated", "")
 
-    if last == yesterday(today):
+    if last == today:
+        pass
+    elif last == yesterday(today):
         profile["current_streak_days"] = profile.get("current_streak_days", 0) + 1
-    elif last != today:
+    else:
         profile["current_streak_days"] = 1
 
     profile["last_updated"] = today
@@ -115,22 +129,27 @@ def update_learner_profile(profile: dict, session: dict):
     profile["total_study_minutes"] = profile.get("total_study_minutes", 0) + session.get("duration_minutes", 0)
 
     for skill, scores in session.get("skill_scores", {}).items():
-        if skill in profile.get("skills", {}):
-            s = profile["skills"][skill]
-            s["last_practiced"] = today
-            s["total_practice_time"] = s.get("total_practice_time", 0) + scores.get("time_minutes", 0)
-            if scores.get("exercises", 0) > 0:
-                new_acc = scores["correct"] / scores["exercises"]
-                old_conf = s.get("confidence", 0)
-                s["confidence"] = round(old_conf * 0.7 + new_acc * 0.3, 2)
-            s["current_level"] = max(s.get("current_level", 0), 1)
+        skills = profile.setdefault("skills", {})
+        s = skills.setdefault(skill, {
+            "current_level": 0, "confidence": 0,
+            "last_practiced": None, "total_practice_time": 0,
+        })
+        s["last_practiced"] = today
+        s["total_practice_time"] = s.get("total_practice_time", 0) + scores.get("time_minutes", 0)
+        if scores.get("exercises", 0) > 0:
+            # confidence is 0-100 int; EWMA against session accuracy (0-100)
+            new_acc_pct = (scores["correct"] / scores["exercises"]) * 100
+            old_conf = s.get("confidence", 0)
+            s["confidence"] = round(old_conf * 0.7 + new_acc_pct * 0.3)
+        s["current_level"] = max(s.get("current_level", 0), 1)
 
     if session.get("focus_areas"):
         profile["focus_areas"] = session["focus_areas"]
 
     for ms in session.get("milestones", []):
+        slug = re.sub(r'[^a-z0-9]+', '_', ms[:30].lower()).strip('_')
         profile.setdefault("achievements", []).append({
-            "id": f"session_{session['session_id']}_{ms[:20].lower().replace(' ', '_')}",
+            "id": f"session_{session['session_id']}_{slug}",
             "name": ms,
             "earned_date": today,
             "description": ms,
@@ -142,71 +161,81 @@ def update_progress_db(progress: dict, session: dict):
     skill_scores = session.get("skill_scores", {})
     total_ex = sum(s.get("exercises", 0) for s in skill_scores.values())
     total_cor = sum(s.get("correct", 0) for s in skill_scores.values())
-    accuracy = round(total_cor / total_ex, 2) if total_ex > 0 else 0.0
+    accuracy = round(total_cor / total_ex, 3) if total_ex > 0 else 0.0
 
-    stats = progress["overall_stats"]
+    stats = progress.setdefault("overall_stats", {
+        "total_sessions": 0, "total_exercises": 0, "total_correct": 0,
+        "total_incorrect": 0, "accuracy_rate": 0.0,
+        "total_study_minutes": 0, "average_session_duration": 0,
+    })
     stats["total_sessions"] = stats.get("total_sessions", 0) + 1
     stats["total_exercises"] = stats.get("total_exercises", 0) + total_ex
     stats["total_correct"] = stats.get("total_correct", 0) + total_cor
     stats["total_incorrect"] = stats.get("total_incorrect", 0) + (total_ex - total_cor)
-    stats["accuracy_rate"] = round(stats["total_correct"] / stats["total_exercises"], 2) if stats["total_exercises"] > 0 else 0.0
+    stats["accuracy_rate"] = round(stats["total_correct"] / stats["total_exercises"], 3) if stats["total_exercises"] > 0 else 0.0
     stats["total_study_minutes"] = stats.get("total_study_minutes", 0) + session.get("duration_minutes", 0)
     stats["average_session_duration"] = round(stats["total_study_minutes"] / stats["total_sessions"])
 
-    progress.setdefault("accuracy_trend", []).append({
-        "date": today,
-        "accuracy": accuracy,
-        "exercises": total_ex,
-    })
+    trend = progress.setdefault("accuracy_trend", [])
+    # Dedup same-day entries: replace if present, else append
+    existing = next((t for t in trend if t.get("date") == today), None)
+    if existing is not None:
+        existing["accuracy"] = accuracy
+        existing["exercises"] = existing.get("exercises", 0) + total_ex
+    else:
+        trend.append({"date": today, "accuracy": accuracy, "exercises": total_ex})
 
     for skill, scores in skill_scores.items():
         sp = progress.setdefault("skill_progress", {}).setdefault(skill, {
-            "sessions": 0, "accuracy": 0.0, "last_practiced": None
+            "sessions": 0, "accuracy": 0.0, "last_practiced": None,
+            "exercises_completed": 0, "correct_count": 0, "incorrect_count": 0,
         })
-        old_sessions = sp["sessions"]
-        sp["sessions"] += 1
+        old_sessions = sp.get("sessions", 0)
+        sp["sessions"] = old_sessions + 1
         new_acc = scores["correct"] / scores["exercises"] if scores.get("exercises", 0) > 0 else 0.0
         sp["accuracy"] = round(
-            (sp["accuracy"] * old_sessions + new_acc) / sp["sessions"], 2
+            (sp.get("accuracy", 0.0) * old_sessions + new_acc) / sp["sessions"], 3
         )
         sp["last_practiced"] = today
+        sp["exercises_completed"] = sp.get("exercises_completed", 0) + scores.get("exercises", 0)
+        sp["correct_count"] = sp.get("correct_count", 0) + scores.get("correct", 0)
+        sp["incorrect_count"] = sp.get("incorrect_count", 0) + (scores.get("exercises", 0) - scores.get("correct", 0))
 
     week_start = get_week_start(today)
     weekly = progress.setdefault("weekly_summary", [])
-    week_entry = None
-    for w in weekly:
-        if w["week_start"] == week_start:
-            week_entry = w
-            break
+    week_entry = next((w for w in weekly if w.get("week_start") == week_start), None)
     if week_entry is None:
         week_entry = {"week_start": week_start, "sessions": 0, "total_minutes": 0, "accuracy": 0.0}
         weekly.append(week_entry)
 
-    old_s = week_entry["sessions"]
-    week_entry["sessions"] += 1
-    week_entry["total_minutes"] += session.get("duration_minutes", 0)
+    old_s = week_entry.get("sessions", 0)
+    week_entry["sessions"] = old_s + 1
+    week_entry["total_minutes"] = week_entry.get("total_minutes", 0) + session.get("duration_minutes", 0)
     week_entry["accuracy"] = round(
-        (week_entry["accuracy"] * old_s + accuracy) / week_entry["sessions"], 2
+        (week_entry.get("accuracy", 0.0) * old_s + accuracy) / week_entry["sessions"], 3
     )
 
-    progress["metadata"]["last_updated"] = today
+    progress.setdefault("metadata", {})["last_updated"] = today
 
 
 def update_mistakes_db(mistakes: dict, session: dict):
     today = session["date"]
+    patterns = mistakes.setdefault("error_patterns", {})
 
     for error in session.get("errors", []):
         pid = error["pattern_id"]
-        patterns = mistakes.setdefault("error_patterns", {})
 
         if pid in patterns:
             pat = patterns[pid]
             pat["frequency"] = pat.get("frequency", 0) + 1
-            pat["last_occurred"] = today
+            pat["last_seen"] = today
+            pat["last_occurred"] = today  # legacy alias kept
             pat["next_review"] = tomorrow(today)
+            pat["consecutive_incorrect"] = pat.get("consecutive_incorrect", 0) + 1
+            pat["consecutive_correct"] = 0
             pat.setdefault("examples", []).append({
-                "your_answer": error.get("your_answer", ""),
-                "correct_answer": error.get("correct_answer", ""),
+                "incorrect": error.get("your_answer", ""),
+                "correct": error.get("correct_answer", ""),
                 "context": error.get("context", ""),
                 "date": today,
             })
@@ -217,22 +246,27 @@ def update_mistakes_db(mistakes: dict, session: dict):
             patterns[pid] = {
                 "category": error.get("category", "other"),
                 "subcategory": error.get("subcategory", ""),
+                "description": error.get("description", ""),
+                "severity": error.get("severity", "minor"),
                 "frequency": 1,
                 "mastery_level": 0,
                 "difficulty_score": error.get("difficulty_score", 0.5),
+                "last_seen": today,
                 "last_occurred": today,
                 "next_review": tomorrow(today),
+                "consecutive_correct": 0,
+                "consecutive_incorrect": 1,
                 "examples": [{
-                    "your_answer": error.get("your_answer", ""),
-                    "correct_answer": error.get("correct_answer", ""),
+                    "incorrect": error.get("your_answer", ""),
+                    "correct": error.get("correct_answer", ""),
                     "context": error.get("context", ""),
                     "date": today,
                 }],
                 "notes": error.get("notes", ""),
             }
 
-    mistakes["metadata"]["last_updated"] = today
-    mistakes["metadata"]["total_patterns_tracked"] = len(mistakes.get("error_patterns", {}))
+    mistakes.setdefault("metadata", {})["last_updated"] = today
+    mistakes["metadata"]["total_patterns_tracked"] = len(patterns)
 
 
 def update_mastery_db(mastery: dict, session: dict, progress: dict):
@@ -242,14 +276,17 @@ def update_mastery_db(mastery: dict, session: dict, progress: dict):
         s = mastery.setdefault("skills", {}).setdefault(skill, {
             "mastery_level": 0, "confidence_score": 0.0,
             "total_practice_time": 0, "last_practiced": None,
+            "practice_count": 0, "avg_accuracy": 0.0,
         })
         s["last_practiced"] = today
         s["total_practice_time"] = s.get("total_practice_time", 0) + scores.get("time_minutes", 0)
+        s["practice_count"] = s.get("practice_count", 0) + scores.get("exercises", 0)
 
         sp = progress.get("skill_progress", {}).get(skill, {})
         acc = sp.get("accuracy", 0)
         sessions = sp.get("sessions", 0)
-        s["confidence_score"] = round(acc, 2)
+        s["confidence_score"] = round(acc, 3)
+        s["avg_accuracy"] = round(acc, 3)
 
         if sessions == 0:
             s["mastery_level"] = 0
@@ -264,23 +301,44 @@ def update_mastery_db(mastery: dict, session: dict, progress: dict):
         else:
             s["mastery_level"] = 5
 
-    mastery["metadata"]["last_updated"] = today
+    mastery.setdefault("metadata", {})["last_updated"] = today
 
 
 def update_spaced_repetition(sr: dict, session: dict):
     today = session["date"]
+    items = sr.setdefault("items", {})
 
     for review in session.get("review_results", []):
         item_id = review["item_id"]
         quality = review["quality"]
-        if item_id in sr.get("items", {}):
-            item = sr["items"][item_id]
+        if item_id in items:
+            item = items[item_id]
             result = calculate_sm2(item, quality)
             item["easiness_factor"] = result["easiness_factor"]
             item["interval_days"] = result["interval_days"]
             item["repetitions"] = result["repetitions"]
             item["due_date"] = date_plus_days(today, result["interval_days"])
             item["last_reviewed"] = today
+            item["last_quality"] = quality
+            item["total_reviews"] = item.get("total_reviews", 0) + 1
+            if quality >= 3:
+                item["consecutive_correct"] = item.get("consecutive_correct", 0) + 1
+                item["consecutive_incorrect"] = 0
+            else:
+                item["consecutive_incorrect"] = item.get("consecutive_incorrect", 0) + 1
+                item["consecutive_correct"] = 0
+            # Mastery: rough map from repetitions and quality
+            if item["repetitions"] >= 5 and item["consecutive_correct"] >= 3:
+                item["mastery_level"] = max(item.get("mastery_level", 0), 3)
+            elif item["repetitions"] >= 2 and item["consecutive_correct"] >= 1:
+                item["mastery_level"] = max(item.get("mastery_level", 0), item.get("mastery_level", 0) + 1 if quality >= 4 else item.get("mastery_level", 0))
+            # priority heuristic
+            if item.get("consecutive_incorrect", 0) >= 2:
+                item["priority"] = "high"
+            elif item.get("mastery_level", 0) >= 3:
+                item["priority"] = "low"
+            else:
+                item["priority"] = item.get("priority", "medium")
             item.setdefault("review_history", []).append({
                 "date": today,
                 "quality": quality,
@@ -289,45 +347,57 @@ def update_spaced_repetition(sr: dict, session: dict):
 
     for vocab in session.get("new_vocabulary", []):
         item_id = vocab["item_id"]
-        if item_id not in sr.get("items", {}):
-            sr.setdefault("items", {})[item_id] = {
-                "item_id": item_id,
-                "item_type": vocab.get("item_type", "vocabulary"),
-                "easiness_factor": 2.5,
+        if item_id not in items:
+            items[item_id] = {
+                "id": item_id,
+                "type": vocab.get("item_type", "vocabulary"),
+                "content": vocab.get("content", ""),
+                "answer": vocab.get("answer", ""),
+                "category": vocab.get("category", ""),
+                "difficulty": vocab.get("difficulty", ""),
+                "created_date": today,
+                "due_date": tomorrow(today),
                 "interval_days": 1,
                 "repetitions": 0,
-                "due_date": tomorrow(today),
+                "easiness_factor": 2.5,
+                "consecutive_correct": 0,
+                "consecutive_incorrect": 0,
                 "last_reviewed": today,
-                "review_history": [{
-                    "date": today,
-                    "quality": vocab.get("initial_quality", 3),
-                    "score": 0,
-                }],
+                "last_quality": vocab.get("initial_quality", 3),
+                "mastery_level": 0,
+                "total_reviews": 0,
+                "priority": vocab.get("priority", "medium"),
             }
 
     for error in session.get("errors", []):
         item_id = error["pattern_id"]
-        if item_id not in sr.get("items", {}):
-            sr.setdefault("items", {})[item_id] = {
-                "item_id": item_id,
-                "item_type": "error_pattern",
-                "easiness_factor": 2.5,
+        if item_id not in items:
+            items[item_id] = {
+                "id": item_id,
+                "type": "error_pattern",
+                "content": error.get("your_answer", ""),
+                "answer": error.get("correct_answer", ""),
+                "category": error.get("category", ""),
+                "difficulty": "",
+                "created_date": today,
+                "due_date": tomorrow(today),
                 "interval_days": 1,
                 "repetitions": 0,
-                "due_date": tomorrow(today),
+                "easiness_factor": 2.5,
+                "consecutive_correct": 0,
+                "consecutive_incorrect": 1,
                 "last_reviewed": today,
-                "review_history": [{
-                    "date": today,
-                    "quality": 2,
-                    "score": 0,
-                }],
+                "last_quality": 2,
+                "mastery_level": 0,
+                "total_reviews": 0,
+                "priority": "high",
             }
 
     # Rebuild review queue
     sr["review_queue"] = {"today": [], "tomorrow": [], "this_week": [], "later": []}
     tom = tomorrow(today)
     week_end = date_plus_days(today, 7)
-    for item_id, item in sr.get("items", {}).items():
+    for item_id, item in items.items():
         due = item.get("due_date", today)
         if due <= today:
             sr["review_queue"]["today"].append(item_id)
@@ -338,32 +408,45 @@ def update_spaced_repetition(sr: dict, session: dict):
         else:
             sr["review_queue"]["later"].append(item_id)
 
-    sr["metadata"]["last_updated"] = today
-    sr["metadata"]["total_items_tracked"] = len(sr.get("items", {}))
+    sr.setdefault("metadata", {})["last_updated"] = today
+    sr["metadata"]["total_items_tracked"] = len(items)
 
 
 def update_session_log(log: dict, session: dict, streak: int):
+    """Matches existing schema: skills_practiced (array), score_breakdown,
+    topics_covered, breakthroughs, focus_next_session, achievements_earned."""
     today = session["date"]
     skill_scores = session.get("skill_scores", {})
     total_ex = sum(s.get("exercises", 0) for s in skill_scores.values())
     total_cor = sum(s.get("correct", 0) for s in skill_scores.values())
 
-    log.setdefault("sessions", []).append({
+    score_breakdown = {
+        skill: round(s["correct"] / s["exercises"], 3) if s.get("exercises", 0) > 0 else 0.0
+        for skill, s in skill_scores.items()
+    }
+
+    entry = {
         "session_id": session["session_id"],
         "date": today,
         "duration_minutes": session.get("duration_minutes", 0),
-        "skill_practiced": session.get("skill_practiced", "mixed"),
+        "skills_practiced": session.get("skills_practiced", list(skill_scores.keys())),
         "command_used": session.get("command_used", "/learn"),
         "exercises_completed": total_ex,
-        "exercises_correct": total_cor,
-        "exercises_incorrect": total_ex - total_cor,
-        "accuracy": round(total_cor / total_ex, 2) if total_ex > 0 else 0.0,
-        "focus_areas": session.get("focus_areas", []),
-        "new_patterns_encountered": [e["pattern_id"] for e in session.get("errors", [])],
-        "mastered_this_session": [],
+        "accuracy": round(total_cor / total_ex, 3) if total_ex > 0 else 0.0,
+        "score_breakdown": score_breakdown,
+        "topics_covered": session.get("topics_covered", []),
+        "breakthroughs": session.get("breakthroughs", []),
+        "focus_next_session": session.get("focus_next_session", session.get("focus_areas", [])),
         "notes": session.get("session_notes", ""),
+        "achievements_earned": session.get("achievements_earned", []),
         "streak_day": streak,
-    })
+    }
+    if session.get("exam_focus"):
+        entry["exam_focus"] = session["exam_focus"]
+    if session.get("critical_errors_identified"):
+        entry["critical_errors_identified"] = session["critical_errors_identified"]
+
+    log.setdefault("sessions", []).append(entry)
 
     for ms in session.get("milestones", []):
         log.setdefault("milestones", []).append({
@@ -372,7 +455,7 @@ def update_session_log(log: dict, session: dict, streak: int):
             "session_id": session["session_id"],
         })
 
-    log["metadata"]["total_sessions"] = len(log["sessions"])
+    log.setdefault("metadata", {})["total_sessions"] = len(log["sessions"])
 
 
 # --- Main ---
@@ -384,7 +467,6 @@ def main():
         print(f"[Fluent] Error: Invalid JSON input: {e}", file=sys.stderr)
         sys.exit(1)
 
-    # Validate required fields
     for field in ("session_id", "date"):
         if field not in session:
             print(f"[Fluent] Error: Missing required field '{field}'", file=sys.stderr)
@@ -392,7 +474,6 @@ def main():
 
     session.setdefault("duration_minutes", 0)
 
-    # Load all databases
     files = {
         "profile": DATA_DIR / "learner-profile.json",
         "progress": DATA_DIR / "progress-db.json",
@@ -403,15 +484,14 @@ def main():
     }
 
     try:
-        data = {k: load_json(p) for k, p in files.items()}
+        originals = {k: load_json(p) for k, p in files.items()}
     except Exception as e:
         print(f"[Fluent] Error loading databases: {e}", file=sys.stderr)
         sys.exit(2)
 
-    # Backup before changes
-    backup_all(f"pre-update-{session['session_id']}")
+    # Work on deep copies so a mid-run exception leaves disk untouched.
+    data = {k: copy.deepcopy(v) for k, v in originals.items()}
 
-    # Run all updaters
     try:
         update_learner_profile(data["profile"], session)
         update_progress_db(data["progress"], session)
@@ -421,12 +501,14 @@ def main():
         streak = data["profile"].get("current_streak_days", 0)
         update_session_log(data["log"], session, streak)
     except Exception as e:
-        print(f"[Fluent] Error updating databases: {e}", file=sys.stderr)
         import traceback
+        print(f"[Fluent] Error updating databases: {e}", file=sys.stderr)
         traceback.print_exc(file=sys.stderr)
         sys.exit(2)
 
-    # Save all atomically
+    # Backup originals BEFORE writing new state.
+    backup_all(f"pre-update-{session['session_id']}")
+
     try:
         for k, p in files.items():
             save_json(p, data[k])
@@ -434,7 +516,7 @@ def main():
         print(f"[Fluent] Error saving databases: {e}", file=sys.stderr)
         sys.exit(2)
 
-    # Summary output
+    # Summary
     stats = data["progress"]["overall_stats"]
     sr_tomorrow = len(data["sr"]["review_queue"].get("tomorrow", []))
     skill_scores = session.get("skill_scores", {})
@@ -443,7 +525,10 @@ def main():
 
     print(f"[Fluent] ✅ Updated 6 databases for session {session['session_id']}")
     print(f"[Fluent] 🔥 Streak: {streak} days | Sessions: {stats['total_sessions']} | Minutes: {stats['total_study_minutes']}")
-    print(f"[Fluent] 📊 This session: {total_cor}/{total_ex} correct ({round(total_cor/total_ex*100)}%)" if total_ex > 0 else "[Fluent] 📊 No exercises recorded")
+    if total_ex > 0:
+        print(f"[Fluent] 📊 This session: {total_cor}/{total_ex} correct ({round(total_cor/total_ex*100)}%)")
+    else:
+        print("[Fluent] 📊 No exercises recorded")
     print(f"[Fluent] 📈 Overall accuracy: {stats['accuracy_rate']*100:.0f}% ({stats['total_exercises']} exercises)")
     print(f"[Fluent] 🧠 SR: {data['sr']['metadata']['total_items_tracked']} items tracked, {sr_tomorrow} due tomorrow")
     print(f"[Fluent] 📝 Errors tracked: {data['mistakes']['metadata']['total_patterns_tracked']} patterns")

--- a/.claude/hooks/update-db.py
+++ b/.claude/hooks/update-db.py
@@ -1,0 +1,455 @@
+#!/usr/bin/env python3
+"""
+Fluent DB Update Script
+Updates all 6 learning databases from a single JSON session report via stdin.
+
+Usage:
+    python3 .claude/hooks/update-db.py <<'EOF'
+    { "session_id": "002", "date": "2026-04-02", ... }
+    EOF
+
+Exit codes: 0=success, 1=validation error, 2=blocking/data error
+"""
+import json
+import sys
+import os
+import shutil
+from datetime import datetime, timedelta
+from pathlib import Path
+
+DATA_DIR = Path("data")
+BACKUP_DIR = Path(".backups")
+
+# --- Utility functions ---
+
+def load_json(path: Path) -> dict:
+    with open(path, 'r', encoding='utf-8') as f:
+        return json.load(f)
+
+
+def save_json(path: Path, data: dict):
+    tmp_path = path.with_suffix('.json.tmp')
+    with open(tmp_path, 'w', encoding='utf-8') as f:
+        json.dump(data, f, indent=2, ensure_ascii=False)
+        f.write('\n')
+        f.flush()
+        os.fsync(f.fileno())
+    os.rename(str(tmp_path), str(path))
+
+
+def date_str(d: datetime) -> str:
+    return d.strftime("%Y-%m-%d")
+
+
+def parse_date(s: str) -> datetime:
+    return datetime.strptime(s, "%Y-%m-%d")
+
+
+def tomorrow(today_str: str) -> str:
+    return date_str(parse_date(today_str) + timedelta(days=1))
+
+
+def yesterday(today_str: str) -> str:
+    return date_str(parse_date(today_str) - timedelta(days=1))
+
+
+def date_plus_days(today_str: str, days: int) -> str:
+    return date_str(parse_date(today_str) + timedelta(days=days))
+
+
+def get_week_start(today_str: str) -> str:
+    d = parse_date(today_str)
+    monday = d - timedelta(days=d.weekday())
+    return date_str(monday)
+
+
+def backup_all(tag: str):
+    backup_path = BACKUP_DIR / tag
+    backup_path.mkdir(parents=True, exist_ok=True)
+    for f in DATA_DIR.glob("*.json"):
+        shutil.copy2(f, backup_path / f.name)
+
+
+# --- SM-2 Algorithm ---
+
+def calculate_sm2(item: dict, quality: int) -> dict:
+    ef = item.get("easiness_factor", 2.5)
+    interval = item.get("interval_days", 1)
+    reps = item.get("repetitions", 0)
+
+    if quality >= 3:
+        if reps == 0:
+            interval = 1
+        elif reps == 1:
+            interval = 6
+        else:
+            interval = round(interval * ef)
+        reps += 1
+    else:
+        reps = 0
+        interval = 1
+
+    ef = ef + (0.1 - (5 - quality) * (0.08 + (5 - quality) * 0.02))
+    ef = max(1.3, ef)
+
+    return {
+        "easiness_factor": round(ef, 2),
+        "interval_days": interval,
+        "repetitions": reps,
+    }
+
+
+# --- Updater functions ---
+
+def update_learner_profile(profile: dict, session: dict):
+    today = session["date"]
+    last = profile.get("last_updated", "")
+
+    if last == yesterday(today):
+        profile["current_streak_days"] = profile.get("current_streak_days", 0) + 1
+    elif last != today:
+        profile["current_streak_days"] = 1
+
+    profile["last_updated"] = today
+    profile["total_sessions"] = profile.get("total_sessions", 0) + 1
+    profile["total_study_minutes"] = profile.get("total_study_minutes", 0) + session.get("duration_minutes", 0)
+
+    for skill, scores in session.get("skill_scores", {}).items():
+        if skill in profile.get("skills", {}):
+            s = profile["skills"][skill]
+            s["last_practiced"] = today
+            s["total_practice_time"] = s.get("total_practice_time", 0) + scores.get("time_minutes", 0)
+            if scores.get("exercises", 0) > 0:
+                new_acc = scores["correct"] / scores["exercises"]
+                old_conf = s.get("confidence", 0)
+                s["confidence"] = round(old_conf * 0.7 + new_acc * 0.3, 2)
+            s["current_level"] = max(s.get("current_level", 0), 1)
+
+    if session.get("focus_areas"):
+        profile["focus_areas"] = session["focus_areas"]
+
+    for ms in session.get("milestones", []):
+        profile.setdefault("achievements", []).append({
+            "id": f"session_{session['session_id']}_{ms[:20].lower().replace(' ', '_')}",
+            "name": ms,
+            "earned_date": today,
+            "description": ms,
+        })
+
+
+def update_progress_db(progress: dict, session: dict):
+    today = session["date"]
+    skill_scores = session.get("skill_scores", {})
+    total_ex = sum(s.get("exercises", 0) for s in skill_scores.values())
+    total_cor = sum(s.get("correct", 0) for s in skill_scores.values())
+    accuracy = round(total_cor / total_ex, 2) if total_ex > 0 else 0.0
+
+    stats = progress["overall_stats"]
+    stats["total_sessions"] = stats.get("total_sessions", 0) + 1
+    stats["total_exercises"] = stats.get("total_exercises", 0) + total_ex
+    stats["total_correct"] = stats.get("total_correct", 0) + total_cor
+    stats["total_incorrect"] = stats.get("total_incorrect", 0) + (total_ex - total_cor)
+    stats["accuracy_rate"] = round(stats["total_correct"] / stats["total_exercises"], 2) if stats["total_exercises"] > 0 else 0.0
+    stats["total_study_minutes"] = stats.get("total_study_minutes", 0) + session.get("duration_minutes", 0)
+    stats["average_session_duration"] = round(stats["total_study_minutes"] / stats["total_sessions"])
+
+    progress.setdefault("accuracy_trend", []).append({
+        "date": today,
+        "accuracy": accuracy,
+        "exercises": total_ex,
+    })
+
+    for skill, scores in skill_scores.items():
+        sp = progress.setdefault("skill_progress", {}).setdefault(skill, {
+            "sessions": 0, "accuracy": 0.0, "last_practiced": None
+        })
+        old_sessions = sp["sessions"]
+        sp["sessions"] += 1
+        new_acc = scores["correct"] / scores["exercises"] if scores.get("exercises", 0) > 0 else 0.0
+        sp["accuracy"] = round(
+            (sp["accuracy"] * old_sessions + new_acc) / sp["sessions"], 2
+        )
+        sp["last_practiced"] = today
+
+    week_start = get_week_start(today)
+    weekly = progress.setdefault("weekly_summary", [])
+    week_entry = None
+    for w in weekly:
+        if w["week_start"] == week_start:
+            week_entry = w
+            break
+    if week_entry is None:
+        week_entry = {"week_start": week_start, "sessions": 0, "total_minutes": 0, "accuracy": 0.0}
+        weekly.append(week_entry)
+
+    old_s = week_entry["sessions"]
+    week_entry["sessions"] += 1
+    week_entry["total_minutes"] += session.get("duration_minutes", 0)
+    week_entry["accuracy"] = round(
+        (week_entry["accuracy"] * old_s + accuracy) / week_entry["sessions"], 2
+    )
+
+    progress["metadata"]["last_updated"] = today
+
+
+def update_mistakes_db(mistakes: dict, session: dict):
+    today = session["date"]
+
+    for error in session.get("errors", []):
+        pid = error["pattern_id"]
+        patterns = mistakes.setdefault("error_patterns", {})
+
+        if pid in patterns:
+            pat = patterns[pid]
+            pat["frequency"] = pat.get("frequency", 0) + 1
+            pat["last_occurred"] = today
+            pat["next_review"] = tomorrow(today)
+            pat.setdefault("examples", []).append({
+                "your_answer": error.get("your_answer", ""),
+                "correct_answer": error.get("correct_answer", ""),
+                "context": error.get("context", ""),
+                "date": today,
+            })
+            pat["examples"] = pat["examples"][-5:]
+            if error.get("notes"):
+                pat["notes"] = error["notes"]
+        else:
+            patterns[pid] = {
+                "category": error.get("category", "other"),
+                "subcategory": error.get("subcategory", ""),
+                "frequency": 1,
+                "mastery_level": 0,
+                "difficulty_score": error.get("difficulty_score", 0.5),
+                "last_occurred": today,
+                "next_review": tomorrow(today),
+                "examples": [{
+                    "your_answer": error.get("your_answer", ""),
+                    "correct_answer": error.get("correct_answer", ""),
+                    "context": error.get("context", ""),
+                    "date": today,
+                }],
+                "notes": error.get("notes", ""),
+            }
+
+    mistakes["metadata"]["last_updated"] = today
+    mistakes["metadata"]["total_patterns_tracked"] = len(mistakes.get("error_patterns", {}))
+
+
+def update_mastery_db(mastery: dict, session: dict, progress: dict):
+    today = session["date"]
+
+    for skill, scores in session.get("skill_scores", {}).items():
+        s = mastery.setdefault("skills", {}).setdefault(skill, {
+            "mastery_level": 0, "confidence_score": 0.0,
+            "total_practice_time": 0, "last_practiced": None,
+        })
+        s["last_practiced"] = today
+        s["total_practice_time"] = s.get("total_practice_time", 0) + scores.get("time_minutes", 0)
+
+        sp = progress.get("skill_progress", {}).get(skill, {})
+        acc = sp.get("accuracy", 0)
+        sessions = sp.get("sessions", 0)
+        s["confidence_score"] = round(acc, 2)
+
+        if sessions == 0:
+            s["mastery_level"] = 0
+        elif sessions < 3 or acc < 0.5:
+            s["mastery_level"] = max(s.get("mastery_level", 0), 1)
+        elif sessions < 5 or acc < 0.65:
+            s["mastery_level"] = max(s.get("mastery_level", 0), 2)
+        elif sessions < 10 or acc < 0.8:
+            s["mastery_level"] = max(s.get("mastery_level", 0), 3)
+        elif sessions < 20 or acc < 0.9:
+            s["mastery_level"] = max(s.get("mastery_level", 0), 4)
+        else:
+            s["mastery_level"] = 5
+
+    mastery["metadata"]["last_updated"] = today
+
+
+def update_spaced_repetition(sr: dict, session: dict):
+    today = session["date"]
+
+    for review in session.get("review_results", []):
+        item_id = review["item_id"]
+        quality = review["quality"]
+        if item_id in sr.get("items", {}):
+            item = sr["items"][item_id]
+            result = calculate_sm2(item, quality)
+            item["easiness_factor"] = result["easiness_factor"]
+            item["interval_days"] = result["interval_days"]
+            item["repetitions"] = result["repetitions"]
+            item["due_date"] = date_plus_days(today, result["interval_days"])
+            item["last_reviewed"] = today
+            item.setdefault("review_history", []).append({
+                "date": today,
+                "quality": quality,
+                "score": review.get("score", 0),
+            })
+
+    for vocab in session.get("new_vocabulary", []):
+        item_id = vocab["item_id"]
+        if item_id not in sr.get("items", {}):
+            sr.setdefault("items", {})[item_id] = {
+                "item_id": item_id,
+                "item_type": vocab.get("item_type", "vocabulary"),
+                "easiness_factor": 2.5,
+                "interval_days": 1,
+                "repetitions": 0,
+                "due_date": tomorrow(today),
+                "last_reviewed": today,
+                "review_history": [{
+                    "date": today,
+                    "quality": vocab.get("initial_quality", 3),
+                    "score": 0,
+                }],
+            }
+
+    for error in session.get("errors", []):
+        item_id = error["pattern_id"]
+        if item_id not in sr.get("items", {}):
+            sr.setdefault("items", {})[item_id] = {
+                "item_id": item_id,
+                "item_type": "error_pattern",
+                "easiness_factor": 2.5,
+                "interval_days": 1,
+                "repetitions": 0,
+                "due_date": tomorrow(today),
+                "last_reviewed": today,
+                "review_history": [{
+                    "date": today,
+                    "quality": 2,
+                    "score": 0,
+                }],
+            }
+
+    # Rebuild review queue
+    sr["review_queue"] = {"today": [], "tomorrow": [], "this_week": [], "later": []}
+    tom = tomorrow(today)
+    week_end = date_plus_days(today, 7)
+    for item_id, item in sr.get("items", {}).items():
+        due = item.get("due_date", today)
+        if due <= today:
+            sr["review_queue"]["today"].append(item_id)
+        elif due == tom:
+            sr["review_queue"]["tomorrow"].append(item_id)
+        elif due <= week_end:
+            sr["review_queue"]["this_week"].append(item_id)
+        else:
+            sr["review_queue"]["later"].append(item_id)
+
+    sr["metadata"]["last_updated"] = today
+    sr["metadata"]["total_items_tracked"] = len(sr.get("items", {}))
+
+
+def update_session_log(log: dict, session: dict, streak: int):
+    today = session["date"]
+    skill_scores = session.get("skill_scores", {})
+    total_ex = sum(s.get("exercises", 0) for s in skill_scores.values())
+    total_cor = sum(s.get("correct", 0) for s in skill_scores.values())
+
+    log.setdefault("sessions", []).append({
+        "session_id": session["session_id"],
+        "date": today,
+        "duration_minutes": session.get("duration_minutes", 0),
+        "skill_practiced": session.get("skill_practiced", "mixed"),
+        "command_used": session.get("command_used", "/learn"),
+        "exercises_completed": total_ex,
+        "exercises_correct": total_cor,
+        "exercises_incorrect": total_ex - total_cor,
+        "accuracy": round(total_cor / total_ex, 2) if total_ex > 0 else 0.0,
+        "focus_areas": session.get("focus_areas", []),
+        "new_patterns_encountered": [e["pattern_id"] for e in session.get("errors", [])],
+        "mastered_this_session": [],
+        "notes": session.get("session_notes", ""),
+        "streak_day": streak,
+    })
+
+    for ms in session.get("milestones", []):
+        log.setdefault("milestones", []).append({
+            "date": today,
+            "milestone": ms,
+            "session_id": session["session_id"],
+        })
+
+    log["metadata"]["total_sessions"] = len(log["sessions"])
+
+
+# --- Main ---
+
+def main():
+    try:
+        session = json.load(sys.stdin)
+    except json.JSONDecodeError as e:
+        print(f"[Fluent] Error: Invalid JSON input: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    # Validate required fields
+    for field in ("session_id", "date"):
+        if field not in session:
+            print(f"[Fluent] Error: Missing required field '{field}'", file=sys.stderr)
+            sys.exit(1)
+
+    session.setdefault("duration_minutes", 0)
+
+    # Load all databases
+    files = {
+        "profile": DATA_DIR / "learner-profile.json",
+        "progress": DATA_DIR / "progress-db.json",
+        "mistakes": DATA_DIR / "mistakes-db.json",
+        "mastery": DATA_DIR / "mastery-db.json",
+        "sr": DATA_DIR / "spaced-repetition.json",
+        "log": DATA_DIR / "session-log.json",
+    }
+
+    try:
+        data = {k: load_json(p) for k, p in files.items()}
+    except Exception as e:
+        print(f"[Fluent] Error loading databases: {e}", file=sys.stderr)
+        sys.exit(2)
+
+    # Backup before changes
+    backup_all(f"pre-update-{session['session_id']}")
+
+    # Run all updaters
+    try:
+        update_learner_profile(data["profile"], session)
+        update_progress_db(data["progress"], session)
+        update_mistakes_db(data["mistakes"], session)
+        update_mastery_db(data["mastery"], session, data["progress"])
+        update_spaced_repetition(data["sr"], session)
+        streak = data["profile"].get("current_streak_days", 0)
+        update_session_log(data["log"], session, streak)
+    except Exception as e:
+        print(f"[Fluent] Error updating databases: {e}", file=sys.stderr)
+        import traceback
+        traceback.print_exc(file=sys.stderr)
+        sys.exit(2)
+
+    # Save all atomically
+    try:
+        for k, p in files.items():
+            save_json(p, data[k])
+    except Exception as e:
+        print(f"[Fluent] Error saving databases: {e}", file=sys.stderr)
+        sys.exit(2)
+
+    # Summary output
+    stats = data["progress"]["overall_stats"]
+    sr_tomorrow = len(data["sr"]["review_queue"].get("tomorrow", []))
+    skill_scores = session.get("skill_scores", {})
+    total_ex = sum(s.get("exercises", 0) for s in skill_scores.values())
+    total_cor = sum(s.get("correct", 0) for s in skill_scores.values())
+
+    print(f"[Fluent] ✅ Updated 6 databases for session {session['session_id']}")
+    print(f"[Fluent] 🔥 Streak: {streak} days | Sessions: {stats['total_sessions']} | Minutes: {stats['total_study_minutes']}")
+    print(f"[Fluent] 📊 This session: {total_cor}/{total_ex} correct ({round(total_cor/total_ex*100)}%)" if total_ex > 0 else "[Fluent] 📊 No exercises recorded")
+    print(f"[Fluent] 📈 Overall accuracy: {stats['accuracy_rate']*100:.0f}% ({stats['total_exercises']} exercises)")
+    print(f"[Fluent] 🧠 SR: {data['sr']['metadata']['total_items_tracked']} items tracked, {sr_tomorrow} due tomorrow")
+    print(f"[Fluent] 📝 Errors tracked: {data['mistakes']['metadata']['total_patterns_tracked']} patterns")
+
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/.gitignore
+++ b/.gitignore
@@ -34,4 +34,5 @@ npm-debug.log*
 # Temp files
 .tmp/
 temp/
+*.json.tmp
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,6 +85,55 @@ You follow these scientifically-proven methods:
 - **Expert**: Reference research, explain WHY rules exist
 - **Adaptive**: Adjust difficulty based on performance
 
+## Database Helper Scripts
+
+Instead of manually editing JSON files with multiple Edit calls, use these scripts:
+
+### Loading all data (session start)
+```bash
+python3 .claude/hooks/read-db.py
+```
+Returns one JSON with all 6 databases + computed fields (`due_reviews_count`, `next_session_id`, `streak_active`).
+
+### Saving session results (session end)
+```bash
+python3 .claude/hooks/update-db.py <<'EOF'
+{
+  "session_id": "002",
+  "date": "2026-04-02",
+  "duration_minutes": 20,
+  "skill_practiced": "mixed",
+  "command_used": "/learn",
+  "skill_scores": {
+    "vocabulary": { "exercises": 5, "correct": 4, "time_minutes": 10 }
+  },
+  "errors": [
+    {
+      "pattern_id": "verb_conjugation_3rd_person",
+      "category": "grammar",
+      "subcategory": "verb_conjugation",
+      "your_answer": "Er spreche",
+      "correct_answer": "Er spricht",
+      "context": "3rd person singular",
+      "difficulty_score": 0.7
+    }
+  ],
+  "new_vocabulary": [
+    { "item_id": "das_haus", "item_type": "vocabulary", "initial_quality": 4 }
+  ],
+  "review_results": [
+    { "item_id": "nein_vs_nicht", "quality": 4 }
+  ],
+  "focus_areas": ["verb_conjugation"],
+  "session_notes": "...",
+  "milestones": ["First lesson!"]
+}
+EOF
+```
+Updates all 6 databases atomically. Only `session_id` and `date` are required; all other fields are optional.
+
+**IMPORTANT:** Always use these scripts instead of manual Edit calls for database updates!
+
 ## Critical Rules
 
 ❗ **ALWAYS** present questions ONE AT A TIME (user explicitly requested this)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,52 +87,14 @@ You follow these scientifically-proven methods:
 
 ## Database Helper Scripts
 
-Instead of manually editing JSON files with multiple Edit calls, use these scripts:
+Prefer the helper scripts over manual Edit calls for database reads and writes:
 
-### Loading all data (session start)
-```bash
-python3 .claude/hooks/read-db.py
-```
-Returns one JSON with all 6 databases + computed fields (`due_reviews_count`, `next_session_id`, `streak_active`).
+- `python3 .claude/hooks/read-db.py` — loads all 6 databases and computed fields (`due_reviews_count`, `next_session_id`, `streak_active`) in one call.
+- `python3 .claude/hooks/update-db.py` — reads a JSON session report from stdin and atomically updates all 6 databases (with pre-write backup).
 
-### Saving session results (session end)
-```bash
-python3 .claude/hooks/update-db.py <<'EOF'
-{
-  "session_id": "002",
-  "date": "2026-04-02",
-  "duration_minutes": 20,
-  "skill_practiced": "mixed",
-  "command_used": "/learn",
-  "skill_scores": {
-    "vocabulary": { "exercises": 5, "correct": 4, "time_minutes": 10 }
-  },
-  "errors": [
-    {
-      "pattern_id": "verb_conjugation_3rd_person",
-      "category": "grammar",
-      "subcategory": "verb_conjugation",
-      "your_answer": "Er spreche",
-      "correct_answer": "Er spricht",
-      "context": "3rd person singular",
-      "difficulty_score": 0.7
-    }
-  ],
-  "new_vocabulary": [
-    { "item_id": "das_haus", "item_type": "vocabulary", "initial_quality": 4 }
-  ],
-  "review_results": [
-    { "item_id": "nein_vs_nicht", "quality": 4 }
-  ],
-  "focus_areas": ["verb_conjugation"],
-  "session_notes": "...",
-  "milestones": ["First lesson!"]
-}
-EOF
-```
-Updates all 6 databases atomically. Only `session_id` and `date` are required; all other fields are optional.
+See `docs/DB_SCRIPTS.md` for the full input schema and examples.
 
-**IMPORTANT:** Always use these scripts instead of manual Edit calls for database updates!
+**IMPORTANT:** Use these scripts instead of manual Edit calls for database updates.
 
 ## Critical Rules
 

--- a/docs/DB_SCRIPTS.md
+++ b/docs/DB_SCRIPTS.md
@@ -1,0 +1,127 @@
+# Database Helper Scripts
+
+Two Python scripts under `.claude/hooks/` manage the six learner databases:
+
+| Script | Purpose |
+|--------|---------|
+| `read-db.py` | Load all 6 databases (+ computed fields) in one call |
+| `update-db.py` | Apply a session report to all 6 databases atomically |
+
+Both operate on files in `data/` relative to the repo root. Always run them
+from the repo root.
+
+## Reading
+
+```bash
+python3 .claude/hooks/read-db.py
+```
+
+Outputs a single JSON object:
+
+```json
+{
+  "databases": {
+    "learner_profile": { ... },
+    "progress_db": { ... },
+    "mistakes_db": { ... },
+    "mastery_db": { ... },
+    "spaced_repetition": { ... },
+    "session_log": { ... }
+  },
+  "computed": {
+    "today": "2026-04-24",
+    "due_reviews_count": 3,
+    "due_review_items": ["vocab_dag", ...],
+    "next_session_id": "session-005",
+    "streak_active": true,
+    "days_since_last_session": 1
+  }
+}
+```
+
+Exit codes: `0` OK, `1` one or more files missing (partial result with
+`_warnings`), `2` critical error.
+
+## Writing
+
+```bash
+python3 .claude/hooks/update-db.py <<'EOF'
+{
+  "session_id": "session-005",
+  "date": "2026-04-24",
+  "duration_minutes": 20,
+  "command_used": "/learn",
+  "skills_practiced": ["vocabulary", "writing"],
+  "skill_scores": {
+    "vocabulary": { "exercises": 5, "correct": 4, "time_minutes": 10 },
+    "writing":    { "exercises": 3, "correct": 3, "time_minutes": 10 }
+  },
+  "errors": [
+    {
+      "pattern_id": "verb_conjugation_3rd_person",
+      "category": "grammar",
+      "subcategory": "verb_conjugation",
+      "your_answer": "Hij spreek",
+      "correct_answer": "Hij spreekt",
+      "context": "3rd person singular",
+      "difficulty_score": 0.7,
+      "severity": "critical",
+      "notes": "optional free text"
+    }
+  ],
+  "new_vocabulary": [
+    {
+      "item_id": "het_huis",
+      "item_type": "vocabulary",
+      "content": "het huis",
+      "answer": "the house",
+      "category": "essential_nouns",
+      "difficulty": "A1",
+      "initial_quality": 4,
+      "priority": "medium"
+    }
+  ],
+  "review_results": [
+    { "item_id": "vocab_dag", "quality": 4 }
+  ],
+  "topics_covered": ["articles", "house_vocabulary"],
+  "breakthroughs": ["First correct use of 'het' vs 'de'"],
+  "focus_next_session": ["Drill de/het article gender"],
+  "session_notes": "Strong session. Article gender still tricky.",
+  "achievements_earned": [],
+  "milestones": []
+}
+EOF
+```
+
+### Required fields
+- `session_id` (string, conventionally `session-NNN`)
+- `date` (YYYY-MM-DD)
+
+Everything else is optional; omitted fields do not update.
+
+### Side effects
+- Backs up `data/*.json` to `.backups/pre-update-<session_id>/` *before*
+  writing.
+- Writes each JSON file via a `.tmp` + `fsync` + `rename` pattern so a crash
+  mid-write cannot leave a half-written file.
+- Rebuilds `spaced-repetition.review_queue` from scratch each run — any manual
+  edits there will be overwritten.
+
+### Exit codes
+- `0` success
+- `1` validation error (bad/missing JSON, missing required field)
+- `2` I/O or logic error (full traceback on stderr; no files were modified)
+
+## Data model notes
+
+- `learner-profile.json` stores `confidence` per skill as an integer 0–100.
+- `progress-db.json` stores `accuracy` values as floats 0.0–1.0.
+- `session-log.json` sessions use `skills_practiced` (array), `score_breakdown`
+  (per-skill float accuracy), `topics_covered`, `breakthroughs`,
+  `focus_next_session`, `achievements_earned`. Session IDs are
+  `session-NNN`.
+- `spaced-repetition.json` items preserve `consecutive_correct/incorrect`,
+  `mastery_level`, `total_reviews`, `priority`, `content`, `answer`,
+  `category`, `difficulty` — supply these in `new_vocabulary` payloads so new
+  items are fully populated.

--- a/tests/test_update_db.py
+++ b/tests/test_update_db.py
@@ -1,0 +1,240 @@
+#!/usr/bin/env python3
+"""
+Smoke test for .claude/hooks/update-db.py.
+
+Runs the script against a fresh fixture DB in a temp dir, feeds it a sample
+session report, and asserts schema invariants on the output files.
+
+Usage:
+    python3 tests/test_update_db.py
+"""
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCRIPT = REPO_ROOT / ".claude" / "hooks" / "update-db.py"
+
+
+def make_fixtures(data_dir: Path):
+    (data_dir / "learner-profile.json").write_text(json.dumps({
+        "learner": {"name": "Test", "target_language": "Dutch",
+                    "current_level": "A1", "target_level": "A2"},
+        "profile_created": "2026-04-20",
+        "last_updated": "2026-04-23",
+        "current_streak_days": 2,
+        "total_sessions": 1,
+        "total_study_minutes": 10,
+        "skills": {
+            "vocabulary": {"current_level": 1, "confidence": 60,
+                           "last_practiced": "2026-04-23",
+                           "total_practice_time": 10}
+        },
+        "focus_areas": [],
+        "achievements": [],
+        "preferences": {}
+    }))
+    (data_dir / "progress-db.json").write_text(json.dumps({
+        "metadata": {"last_updated": "2026-04-23", "language": "Dutch",
+                     "tracking_started": "2026-04-20"},
+        "overall_stats": {"total_sessions": 1, "total_exercises": 4,
+                          "total_correct": 3, "total_incorrect": 1,
+                          "accuracy_rate": 0.75,
+                          "total_study_minutes": 10,
+                          "average_session_duration": 10},
+        "accuracy_trend": [{"date": "2026-04-23", "accuracy": 0.75,
+                            "exercises": 4}],
+        "skill_progress": {
+            "vocabulary": {"sessions": 1, "accuracy": 0.75,
+                           "last_practiced": "2026-04-23",
+                           "exercises_completed": 4, "correct_count": 3,
+                           "incorrect_count": 1}
+        },
+        "weekly_summary": []
+    }))
+    (data_dir / "mistakes-db.json").write_text(json.dumps({
+        "metadata": {"last_updated": "2026-04-23",
+                     "total_patterns_tracked": 0, "language": "Dutch"},
+        "error_patterns": {}
+    }))
+    (data_dir / "mastery-db.json").write_text(json.dumps({
+        "metadata": {"last_updated": "2026-04-23", "language": "Dutch"},
+        "skills": {
+            "vocabulary": {"mastery_level": 1, "confidence_score": 0.75,
+                           "total_practice_time": 10,
+                           "last_practiced": "2026-04-23",
+                           "practice_count": 4, "avg_accuracy": 0.75}
+        },
+        "patterns": {}
+    }))
+    (data_dir / "spaced-repetition.json").write_text(json.dumps({
+        "metadata": {"algorithm": "SM-2", "last_updated": "2026-04-23",
+                     "total_items_tracked": 1, "language": "Dutch"},
+        "review_queue": {"today": [], "tomorrow": ["vocab_dag"],
+                         "this_week": [], "later": []},
+        "items": {
+            "vocab_dag": {
+                "id": "vocab_dag", "type": "vocabulary", "content": "dag",
+                "answer": "day / hi-bye", "category": "greetings",
+                "difficulty": "A1", "created_date": "2026-04-23",
+                "due_date": "2026-04-24", "interval_days": 1,
+                "repetitions": 1, "easiness_factor": 2.5,
+                "consecutive_correct": 1, "consecutive_incorrect": 0,
+                "last_reviewed": "2026-04-23", "last_quality": 4,
+                "mastery_level": 1, "total_reviews": 1, "priority": "medium"
+            }
+        }
+    }))
+    (data_dir / "session-log.json").write_text(json.dumps({
+        "metadata": {"language": "Dutch", "learner_name": "Test",
+                     "total_sessions": 1},
+        "sessions": [{
+            "session_id": "session-001", "date": "2026-04-23",
+            "duration_minutes": 10,
+            "skills_practiced": ["vocabulary"],
+            "exercises_completed": 4, "accuracy": 0.75,
+            "score_breakdown": {"vocabulary": 0.75},
+            "topics_covered": [], "breakthroughs": [],
+            "focus_next_session": [], "notes": "",
+            "achievements_earned": []
+        }],
+        "milestones": []
+    }))
+
+
+SESSION_PAYLOAD = {
+    "session_id": "session-002",
+    "date": "2026-04-24",
+    "duration_minutes": 15,
+    "command_used": "/learn",
+    "skills_practiced": ["vocabulary"],
+    "skill_scores": {
+        "vocabulary": {"exercises": 5, "correct": 4, "time_minutes": 15}
+    },
+    "errors": [{
+        "pattern_id": "verb_spreek",
+        "category": "grammar",
+        "subcategory": "verb_conjugation",
+        "your_answer": "Hij spreek",
+        "correct_answer": "Hij spreekt",
+        "context": "3rd person",
+        "severity": "critical",
+        "difficulty_score": 0.7
+    }],
+    "new_vocabulary": [{
+        "item_id": "het_huis",
+        "item_type": "vocabulary",
+        "content": "het huis",
+        "answer": "the house",
+        "category": "nouns",
+        "difficulty": "A1",
+        "initial_quality": 4
+    }],
+    "review_results": [{"item_id": "vocab_dag", "quality": 5}],
+    "topics_covered": ["house_vocab"],
+    "breakthroughs": ["Got 'het huis' on first try"],
+    "focus_next_session": ["de/het drill"],
+    "session_notes": "Good session.",
+    "milestones": []
+}
+
+
+class UpdateDbSmokeTest(unittest.TestCase):
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp(prefix="fluent-test-"))
+        (self.tmp / "data").mkdir()
+        make_fixtures(self.tmp / "data")
+
+    def tearDown(self):
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def _run(self, payload: dict):
+        proc = subprocess.run(
+            ["python3", str(SCRIPT)],
+            input=json.dumps(payload).encode(),
+            cwd=str(self.tmp),
+            capture_output=True,
+        )
+        return proc
+
+    def test_happy_path(self):
+        proc = self._run(SESSION_PAYLOAD)
+        self.assertEqual(proc.returncode, 0,
+                         msg=f"stdout={proc.stdout!r} stderr={proc.stderr!r}")
+
+        with open(self.tmp / "data" / "session-log.json") as f:
+            log = json.load(f)
+        latest = log["sessions"][-1]
+        self.assertEqual(latest["session_id"], "session-002")
+        self.assertIn("skills_practiced", latest)
+        self.assertIsInstance(latest["skills_practiced"], list)
+        self.assertIn("score_breakdown", latest)
+        self.assertIn("topics_covered", latest)
+        self.assertIn("breakthroughs", latest)
+        self.assertIn("focus_next_session", latest)
+        self.assertIn("achievements_earned", latest)
+        self.assertEqual(latest["streak_day"], 3)  # was 2, yesterday -> +1
+
+        with open(self.tmp / "data" / "learner-profile.json") as f:
+            profile = json.load(f)
+        self.assertEqual(profile["current_streak_days"], 3)
+        conf = profile["skills"]["vocabulary"]["confidence"]
+        self.assertIsInstance(conf, int)
+        self.assertGreaterEqual(conf, 0)
+        self.assertLessEqual(conf, 100)
+
+        with open(self.tmp / "data" / "spaced-repetition.json") as f:
+            sr = json.load(f)
+        dag = sr["items"]["vocab_dag"]
+        # Schema preserved
+        for k in ("consecutive_correct", "consecutive_incorrect",
+                  "mastery_level", "total_reviews", "priority",
+                  "content", "answer", "category", "difficulty"):
+            self.assertIn(k, dag, f"lost field {k} on vocab_dag")
+        self.assertEqual(dag["total_reviews"], 2)  # was 1, +1 review
+        self.assertEqual(dag["last_quality"], 5)
+
+        # New vocabulary item fully populated
+        huis = sr["items"]["het_huis"]
+        for k in ("id", "type", "content", "answer", "category",
+                  "difficulty", "due_date", "interval_days", "repetitions",
+                  "easiness_factor", "consecutive_correct",
+                  "consecutive_incorrect", "mastery_level",
+                  "total_reviews", "priority"):
+            self.assertIn(k, huis, f"new item missing {k}")
+
+        with open(self.tmp / "data" / "mistakes-db.json") as f:
+            mistakes = json.load(f)
+        self.assertIn("verb_spreek", mistakes["error_patterns"])
+        pat = mistakes["error_patterns"]["verb_spreek"]
+        self.assertEqual(pat["consecutive_incorrect"], 1)
+        self.assertEqual(pat["examples"][-1]["incorrect"], "Hij spreek")
+        self.assertEqual(pat["examples"][-1]["correct"], "Hij spreekt")
+
+        # Backup directory exists
+        backup = self.tmp / ".backups" / "pre-update-session-002"
+        self.assertTrue(backup.exists(), "pre-update backup missing")
+
+    def test_missing_required_field_exits_1(self):
+        proc = self._run({"date": "2026-04-24"})  # no session_id
+        self.assertEqual(proc.returncode, 1)
+
+    def test_same_day_does_not_bump_streak(self):
+        # Profile last_updated = 2026-04-23; send a session on 2026-04-23.
+        payload = dict(SESSION_PAYLOAD)
+        payload["session_id"] = "session-003"
+        payload["date"] = "2026-04-23"
+        proc = self._run(payload)
+        self.assertEqual(proc.returncode, 0, msg=proc.stderr)
+        with open(self.tmp / "data" / "learner-profile.json") as f:
+            profile = json.load(f)
+        self.assertEqual(profile["current_streak_days"], 2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- **`read-db.py`** — loads all 6 learner databases in one call (replaces 6 `Read` tool calls at session start). Returns combined JSON with computed fields (`due_reviews_count`, `next_session_id`, `streak_active`).
- **`update-db.py`** — atomically updates all 6 databases from a single JSON session report via stdin (replaces 10+ `Edit` tool calls at session end). Implements SM-2 spaced repetition algorithm, streak tracking, mastery calculation, and error pattern management.
- **CLAUDE.md** — documents script usage with input schema and examples so Claude knows to use scripts instead of manual edits.
- **.gitignore** — adds `*.json.tmp` for atomic write temp files.

### Why
After each learning session, Claude was manually editing 6 JSON files with 10+ sequential `Edit` calls — often taking longer than the lesson itself. These scripts reduce it to a single `Bash` call each for reading and writing, with atomic writes (`.tmp` + `rename`) and automatic pre-update backups.

### Usage
```bash
# Session start: load all data
python3 .claude/hooks/read-db.py

# Session end: save results
python3 .claude/hooks/update-db.py <<'EOF_DATA'
{ "session_id": "002", "date": "2026-04-02", "duration_minutes": 20, ... }
EOF_DATA
```

## Test plan

- [x] `read-db.py` outputs valid JSON with all 6 databases and computed fields
- [x] `update-db.py` correctly updates all 6 files from a test session payload
- [x] Atomic writes confirmed (`.tmp` → `rename`)
- [x] Pre-update backup created automatically
- [x] Used in a real learning session (session 002) — all databases updated correctly in one call

🤖 Generated with [Claude Code](https://claude.com/claude-code)