### PR TITLE
feat: /wortchallenge — Obsidian vault → Fluent SR queue bridge

### DIFF
--- a/.agents/skills/db-updater/SKILL.md
+++ b/.agents/skills/db-updater/SKILL.md
@@ -1,0 +1,144 @@
+---
+name: db-updater
+description: Atomically update all 6 Fluent learner databases (learner-profile, progress, mistakes, mastery, spaced-repetition, session-log) at session end by calling .claude/hooks/update-db.py with a single JSON payload. Use at the end of every practice session — writing, vocab, speaking, reading, review, learn — to persist the session's errors, review results, new vocabulary, and session metadata.
+---
+
+# DB Updater
+
+## Overview
+
+Every practice skill ends with a DB update. Instead of hand-editing 6 JSON files (error-prone, racy, easy to desync), pipe one JSON report to `update-db.py`. The script runs pre-write backups, validates the payload, applies all changes atomically via `.tmp + fsync + rename`, and rebuilds the spaced-repetition queue.
+
+## When to Use
+
+Load this skill whenever the tutor:
+
+- Finishes a practice session and needs to persist results.
+- Needs to add new vocabulary to the spaced-repetition queue.
+- Needs to record new errors, review results, or mastery changes.
+- Needs to bump `total_sessions`, `current_streak_days`, or `total_study_minutes`.
+
+Skip this skill for read-only operations (use the `progress` skill or `read-db.py` directly) and during session setup (use `setup` skill instead — `update-db.py` is for session deltas, not bootstrap).
+
+## Instructions
+
+### 1. Call the script
+
+Run from the repo root:
+
+```bash
+python3 .claude/hooks/update-db.py <<'EOF'
+{ ...payload... }
+EOF
+```
+
+Exit codes: `0` success, `1` validation error, `2` I/O error.
+
+### 2. Fill the payload
+
+**Required fields**
+
+- `session_id` — string, convention `session-NNN`. Use `computed.next_session_id` from `read-db.py`.
+- `date` — YYYY-MM-DD.
+
+**Optional fields** — omit to skip. Full canonical example (copy-paste this and fill in):
+
+```
+${CLAUDE_PLUGIN_ROOT:-${CLAUDE_PROJECT_DIR:-.}}/.claude/references/db-updater-payload.example.json
+```
+
+Key blocks the example covers: `skill_scores`, `errors[]`, `new_vocabulary[]`, `review_results[]`, `topics_covered`, `breakthroughs`, `focus_next_session`, `session_notes`, `achievements_earned`, `milestones`.
+
+### 3. Field notes
+
+- `errors[]` — one entry per distinct mistake this session. Collapse duplicates (same `pattern_id`) before sending; `frequency` is bumped by the script.
+- `new_vocabulary[]` — items the learner met for the first time. Fill every field; incomplete entries yield incomplete spaced-repetition records.
+- `review_results[]` — items already in the queue that were reviewed. The script runs SM-2 on each. See the `sm2-calculator` skill. Mapping: `quality = floor(score / 2)`.
+- `skill_scores[].correct` counts correct exercises, not a percentage. Accuracy is derived.
+- `confidence` in `learner-profile.skills` is 0–100 integer; `accuracy` in `progress-db` is 0.0–1.0 float. The script handles the conversion.
+
+### 4. Read before writing
+
+Always call `read-db.py` at session start to get current state + `next_session_id`. Don't read each JSON file separately:
+
+```bash
+python3 .claude/hooks/read-db.py
+```
+
+Returns all 6 databases plus computed fields (`due_reviews_count`, `next_session_id`, `streak_active`, `days_since_last_session`).
+
+## Examples
+
+### Example 1 — /review session with 5 items
+
+```bash
+python3 .claude/hooks/update-db.py <<'EOF'
+{
+  "session_id": "session-012",
+  "date": "2026-04-24",
+  "duration_minutes": 12,
+  "command_used": "/review",
+  "skills_practiced": ["vocabulary", "grammar"],
+  "skill_scores": {
+    "vocabulary": { "exercises": 3, "correct": 3, "time_minutes": 7 },
+    "grammar":    { "exercises": 2, "correct": 1, "time_minutes": 5 }
+  },
+  "review_results": [
+    { "item_id": "vocab_huis", "quality": 5 },
+    { "item_id": "vocab_deur", "quality": 4 },
+    { "item_id": "vocab_raam", "quality": 5 },
+    { "item_id": "grammar_omdat_word_order", "quality": 2 },
+    { "item_id": "grammar_past_tense", "quality": 4 }
+  ],
+  "errors": [
+    {
+      "pattern_id": "grammar_omdat_word_order",
+      "category": "grammar",
+      "your_answer": "omdat ik ben moe",
+      "correct_answer": "omdat ik moe ben",
+      "context": "subordinate clause word order",
+      "severity": "critical"
+    }
+  ],
+  "focus_next_session": ["Drill 'omdat' word order"]
+}
+EOF
+```
+
+### Example 2 — /vocab session with a new word
+
+```bash
+python3 .claude/hooks/update-db.py <<'EOF'
+{
+  "session_id": "session-013",
+  "date": "2026-04-25",
+  "command_used": "/vocab",
+  "skills_practiced": ["vocabulary"],
+  "new_vocabulary": [
+    {
+      "item_id": "vocab_keuken",
+      "item_type": "vocabulary",
+      "content": "de keuken",
+      "answer": "the kitchen",
+      "category": "household_rooms",
+      "difficulty": "A1",
+      "initial_quality": 4,
+      "priority": "medium"
+    }
+  ]
+}
+EOF
+```
+
+## Critical Rules
+
+- **Call once per session, at the end.** The script rebuilds the review queue each run — partial updates risk inconsistency.
+- **Never hand-edit `spaced-repetition.review_queue`.** It's regenerated from scratch on every run.
+- **Same `session_id` replaces.** Sending the same ID twice overwrites the first call. Useful for corrections, dangerous if unintentional.
+- **Backups are automatic.** Written to `.backups/pre-update-<session_id>/` before any change. Check there to roll back.
+- **Exit code 1 means validation failed, no files touched.** Fix the payload and retry.
+- **Exit code 2 means I/O failure, no files touched.** Check disk space, permissions, then retry.
+
+## Why This Matters
+
+Six interdependent JSON files must agree: a new `session-log` entry, a bumped `total_sessions`, updated SM-2 params, new mistake patterns, recalculated accuracy, refreshed streak. Hand-editing causes silent desync — streak says 7 days but session-log has 6 entries, mastery says 4 stars but accuracy says 45%. The script is the single source of truth.

--- a/.agents/skills/feedback-formatter/SKILL.md
+++ b/.agents/skills/feedback-formatter/SKILL.md
@@ -1,0 +1,98 @@
+---
+name: feedback-formatter
+description: Canonical feedback template for every learner answer in the Fluent system — celebrate correct parts, correct mistakes with category and brief explanation, show the full correct version, score out of 10, and classify severity (🔴 critical / 🟡 moderate / 🟢 minor). Use in every practice session (writing, vocab, speaking, reading, review) immediately after the learner submits an answer.
+---
+
+# Feedback Formatter
+
+## Overview
+
+Every practice session ends each turn with immediate feedback. Consistency matters — the learner builds mental models from the structure, and error patterns we mine from session files depend on predictable markers (❌, ✅, severity emoji). This skill defines the single feedback shape used across all Fluent practice skills.
+
+## When to Use
+
+Load this skill whenever the tutor:
+
+- Grades a learner answer in any practice skill (`learn`, `vocab`, `writing`, `speaking`, `reading`, `review`).
+- Needs to classify an error by severity before writing to `mistakes-db.json`.
+- Needs to tag an error by category (grammar, vocabulary, prepositions, etc.).
+
+Skip this skill for non-feedback output (greetings, summaries, progress reports).
+
+## Instructions
+
+### 1. Standard template
+
+```markdown
+{✅ or ❌} {one-line encouragement or gentle correction}
+
+**Corrections:**
+- ❌ "{wrong_part}" → **"{correct_part}"** ({category} — {brief_why})
+- ✅ "{correct_part}" — {specific_praise}
+
+**Correct version:**
+"{full_correct_sentence}"
+
+**Score: {X}/10** {emoji} {short_comment}
+
+---
+```
+
+Skip the ❌ block if the answer is fully correct. Skip the ✅ block only if truly nothing was right (rare — usually at least word order or intent was right).
+
+### 2. Tag severity on every error
+
+| Symbol | Severity | Meaning | Example |
+|--------|----------|---------|---------|
+| 🔴 | Critical | Breaks communication or exam-blocker | Formal/informal mix in formal email; wrong subordinate-clause word order |
+| 🟡 | Moderate | Noticeable but understandable | Preposition error, missing article |
+| 🟢 | Minor | Low priority | Spelling, punctuation, accent marks |
+
+A single answer may contain multiple errors of different severity — tag each.
+
+### 3. Use these category labels
+
+These feed `mistakes-db.json`:
+
+- `grammar` — word order, conjugation, clause structure
+- `formal_informal` — u/je, uw/jouw, register mismatch
+- `vocabulary` — wrong word, English mixing, register-wrong synonym
+- `spelling` — minor
+- `prepositions` — om/op/in/bij/naar/etc.
+- `articles` — de/het, definite/indefinite
+- `missing` — omitted greeting, closing, required word
+
+### 4. Tone rules
+
+- **Encourage before correcting.** Open with a ✅ or a warm ❌ (`"Close! Let's tune one word."`), not a bare `Wrong.`.
+- **Explain why, not just what.** `"Ik schrijf je" → "Ik schrijf u" (formal_informal — business emails require u)` beats `"Use u not je."`.
+- **Name the pattern.** Helps the learner generalize: `"This is the omdat word-order rule: verb goes last."`.
+- **Celebrate progress.** `"You didn't miss this last time — well done."` when `mistakes-db` shows improvement.
+- **Emojis on.** The learner's profile has `use_emojis: true` by default. Keep them.
+
+### 5. Hand score to SM-2
+
+After scoring, feed the score into the SM-2 update via the `sm2-calculator` skill: `quality = floor(score / 2)`.
+
+## Examples
+
+See `.claude/references/feedback-template.md` for fully-rendered examples (mostly-correct answer with a minor slip; critical error with severity tagging). The reference file is the authoritative version — keep it and this skill in sync if updating.
+
+Quick pattern:
+
+- Fully correct: open with ✅, skip ❌ block, list 1-2 ✅ strengths, show "Correct version" for echo, score 9-10/10.
+- Mistakes: open with warm ❌, list each correction with severity emoji + category + brief why, show full correct version, score with breakdown if the answer is long.
+
+## Critical Rules
+
+- **Always use the template exactly.** Deviations break session-file parsing downstream.
+- **Severity tag is mandatory** on every ❌ line. Drives spaced-repetition priority.
+- **One score per answer.** Total out of 10, with optional breakdown (grammar/vocab/structure) for long answers like writing tasks.
+- **Never skip the "Correct version".** Even if perfect, echoing the target form reinforces motor memory.
+
+## Why This Matters
+
+Structured, consistent feedback:
+1. Lets the learner scan for what to fix at a glance.
+2. Makes session files parseable so `PRACTICE.md` analysis + `/results` mining work.
+3. Populates `mistakes-db.json` categories cleanly — which feeds spaced repetition, which drives the whole system.

--- a/.agents/skills/learn/SKILL.md
+++ b/.agents/skills/learn/SKILL.md
@@ -1,0 +1,204 @@
+---
+name: learn
+description: Main adaptive language-learning session that mixes skills (writing, speaking, vocabulary, reading) and exercise types based on the learner's current level, weak patterns, and due reviews. Triggered only when the learner types /learn. Greets the learner, shows today's plan, asks what to practice, runs interleaved exercises one at a time, and updates all databases at the end.
+allowed-tools: Read, Write, Bash
+disable-model-invocation: true
+---
+
+# Main Adaptive Learning Session
+
+## Overview
+
+The flagship command. Interleaves skills, adapts difficulty per answer, and covers the whole evidence-based loop: active recall → immediate feedback → spaced repetition → tracking. Typically runs 15-20 min, mixing 2-3 patterns to force discrimination.
+
+## When to Use
+
+Trigger this skill only when the learner types `/learn`. The skill is gated with `disable-model-invocation: true` — an ambiguous auto-trigger would launch a 20-min interactive session and mutate 6 JSON databases.
+
+Skip this skill the very first time a learner runs the system — route to `/setup` instead.
+
+## Instructions
+
+### 1. Load learner context
+
+```bash
+python3 .claude/hooks/read-db.py
+```
+
+Need all 6 DBs. If any missing, direct the learner to `/setup` and stop.
+
+### 2. Analyze today's plan
+
+- **Streak:** `learner-profile.current_streak_days`
+- **Due reviews:** `computed.due_reviews_count`
+- **Weak patterns:** `mistakes-db.error_patterns` where `mastery_level <= 2` (descending by frequency)
+- **Recent performance:** `progress-db.weekly_summary`
+- **Skills not practiced recently:** check `mastery-db.skills_mastery.{skill}.last_practiced`
+
+### 3. Greet
+
+```markdown
+# {greeting in target language}, {name}! 👋
+
+**Today's Status:**
+- 🔥 Streak: {X} {day/days}
+- 📚 Review items due: {Y}
+- 🎯 Focus area: {weakest skill or top weak pattern}
+- ⭐ Level: {current} → {target} ({progress}%)
+
+**What would you like to practice today?**
+
+1. 📝 Writing (emails, letters, forms)
+2. 🗣️ Speaking (typed conversation)
+3. 📖 Vocabulary (flashcard drills)
+4. 👀 Reading (comprehension)
+5. 🔄 Spaced Review (today's due items)
+6. 🎲 Surprise me! (adaptive mix)
+
+**Type a number or skill name:**
+```
+
+### 4. Route
+
+- 1-5 → hand off to the matching skill (`writing`, `speaking`, `vocab`, `reading`, `review`). Those skills cover everything needed; this skill's job here is just to dispatch.
+- 6 (adaptive mix) → use this skill's own exercise sequencer (below).
+
+### 5. Adaptive mix (option 6)
+
+Plan a 20-min session:
+
+1. **Warm-up (3 min)** — easy vocabulary recognition on already-strong words. Builds confidence.
+2. **Targeted drill 1 (7 min)** — top weak pattern. 3-4 isolated exercises + 1 application.
+3. **Targeted drill 2 (5 min)** — second weak pattern. Same structure.
+4. **Integration (5 min)** — short writing or speaking task that forces both patterns together.
+
+Run one exercise at a time with immediate feedback via `feedback-formatter`.
+
+Use `session-analyzer` to choose which patterns to target.
+
+### 6. Adaptive difficulty
+
+After every 3-4 exercises, check rolling accuracy:
+
+- **<50%** → drop difficulty (smaller chunks, more scaffolding, offer hints)
+- **50-70%** → hold — this is the target zone
+- **>70%** → raise difficulty (longer sentences, less scaffolding, rarer vocabulary)
+
+Formula reference:
+
+```
+if mastery_level <= 1:
+    difficulty = "easy"
+elif mastery_level == 2:
+    difficulty = "medium" if recent_accuracy > 0.60 else "easy"
+elif mastery_level == 3:
+    difficulty = "medium" if recent_accuracy > 0.70 else "medium"
+elif mastery_level >= 4:
+    difficulty = "hard" if recent_accuracy > 0.80 else "medium"
+```
+
+### 7. Exercise types by skill
+
+**Writing**: sentence completion, translation, error correction, full email, reordering.
+
+**Speaking**: personal Qs, picture description, role-play, phonetic typing.
+
+**Vocabulary**: recognition, production, cloze, associations, synonym matching.
+
+**Reading**: short text + comprehension, cloze paragraph, true/false, summarization.
+
+### 8. Per-answer feedback
+
+Use `feedback-formatter` template. Score 0-10 + severity tag. Stage for end-of-session update.
+
+Also prompt the learner to **retype** the correct form after a critical mistake — motor memory helps:
+
+```markdown
+Now type the correct version yourself: "{correct_sentence}"
+```
+
+### 9. Session end
+
+```markdown
+## 🎉 Session Complete!
+
+**Today's Stats:**
+- ⏱️ Duration: {X} min
+- ✅ Exercises: {Y}
+- 📊 Accuracy: {Z}%
+- 📈 Improvement: +{N}% from start
+
+**Breakthroughs:** ✨
+- {what mastered or improved}
+
+**Next Time Focus:**
+- {what to practice next}
+
+**Streak:** 🔥 {X} {day/days}! {motivational line}
+
+{goodbye in target language}! 👏
+```
+
+Then use the `db-updater` skill:
+
+- `command_used: "/learn"`
+- `skills_practiced: [all skills touched]`
+- `skill_scores` per skill
+- `errors[]`, `new_vocabulary[]`, `review_results[]`
+- `breakthroughs[]`, `focus_next_session[]`, `session_notes`
+
+Save exchange to `/results/learn-session-{NNN}.md`.
+
+## Examples
+
+### Example 1 — greeting for an active learner
+
+> # Goedemorgen, Mohammad! 👋
+>
+> **Today's Status:**
+> - 🔥 Streak: 6 days
+> - 📚 Review items due: 6
+> - 🎯 Focus area: formal_informal confusion (5 total occurrences)
+> - ⭐ Level: A1 → A2 (38%)
+>
+> **What would you like to practice today?**
+>
+> 1. 📝 Writing (emails, letters, forms)
+> 2. 🗣️ Speaking (typed conversation)
+> 3. 📖 Vocabulary (flashcard drills)
+> 4. 👀 Reading (comprehension)
+> 5. 🔄 Spaced Review (today's due items)
+> 6. 🎲 Surprise me! (adaptive mix)
+>
+> **Type a number or skill name:**
+
+### Example 2 — adaptive mix mid-session
+
+After 4 exercises, accuracy is 55% (target zone). Hold difficulty; introduce pattern #2:
+
+> Nice — you're right in the sweet spot. Let's switch patterns now.
+>
+> ## Exercise 5: `omdat` word order
+>
+> Rewrite this correctly: "omdat ik ben te laat"
+>
+> **Type your answer:**
+
+## Critical Rules
+
+- **Never auto-invoke.** Gated; 15-20 min interactive + DB writes.
+- **Always load all 6 DBs at start.** Missing context → generic, demotivating content.
+- **One exercise at a time.**
+- **Interleave.** Don't drill one pattern for 20 min — mix 2-3 patterns to force discrimination.
+- **Use the helper skills** (`sm2-calculator`, `feedback-formatter`, `db-updater`, `session-analyzer`) — don't reimplement.
+- **Use the learner's name + target-language greetings** throughout.
+- **Celebrate progress.** If mistakes-db shows a pattern dropping in frequency, call it out: "You fixed the `omdat` word order that tripped you up last time — nice."
+
+## Personality Notes
+
+- Encouraging — celebrate small wins, be gentle with mistakes.
+- Systematic — track everything, quantify progress.
+- Fun — emojis, gamification, mini-celebrations on streaks/milestones.
+- Patient — one question at a time.
+- Expert — explain *why*, not just *what*.
+- Adaptive — adjust to the learner's performance in real time.

--- a/.agents/skills/progress/SKILL.md
+++ b/.agents/skills/progress/SKILL.md
@@ -1,0 +1,224 @@
+---
+name: progress
+description: Show the learner's language learning progress, statistics, mastery levels, streak, and achievements. Use when the learner asks "how am I doing", "show my progress", "stats", "dashboard", "what's my streak", "how many words have I learned", or invokes /progress. Read-only — safe to auto-invoke.
+allowed-tools: Read, Bash
+---
+
+# Progress Dashboard
+
+## Overview
+
+Show the learner a comprehensive, personalized progress report with visual statistics, skill mastery levels, trends, and next goals. This is read-only: do not modify any database files.
+
+## When to Use
+
+Trigger this skill when:
+
+- Learner types `/progress`.
+- Learner asks about their progress, statistics, streak, mastery, achievements, or how they're improving.
+- Learner asks "how am I doing", "show me my stats", "am I getting better".
+- After a session ends, if the learner wants a broader view than the session summary.
+
+Skip this skill when the learner is mid-practice — the ongoing session skill already shows per-turn feedback, and opening the full dashboard interrupts the flow.
+
+## Instructions
+
+### 1. Load all 6 databases
+
+Prefer the helper script over manual Read calls:
+
+```bash
+python3 .claude/hooks/read-db.py
+```
+
+This returns a single JSON with all 6 databases + computed fields (`due_reviews_count`, `next_session_id`, `streak_active`, `days_since_last_session`).
+
+If the helper is unavailable, fall back to reading each file directly. Resolve the data directory via `fluent_paths.data_dir()` first — do NOT hardcode `data/` (plugin installs store data under `~/.codex/fluent-data/`):
+
+- `<data_dir>/learner-profile.json`
+- `<data_dir>/progress-db.json`
+- `<data_dir>/mastery-db.json`
+- `<data_dir>/mistakes-db.json`
+- `<data_dir>/spaced-repetition.json`
+- `<data_dir>/session-log.json`
+
+If any are missing, point the learner at `/setup` and stop.
+
+### 2. Generate the report
+
+Use this exact structure. Fill in values from the databases; compute percentages and progress bars yourself.
+
+```markdown
+# 📊 {learner_name}'s {target_language} Learning Dashboard
+
+**Last Updated:** {today}
+
+---
+
+## 🎯 Overview
+
+**Current Level:** {current_level}
+**Target Level:** {target_level}
+**Progress to {next_level}:** {progress_bar} {percentage}%
+
+**Days Studying:** {total_days}
+**Current Streak:** 🔥 {streak_days} {day_or_days} {streak_message}
+**Total Sessions:** {total_sessions}
+**Total Study Time:** {total_minutes} minutes ({hours} hours)
+
+---
+
+## 💪 Skills Mastery
+
+### Writing ✍️
+**Level:** {n}/5 {stars}
+**Accuracy:** {percent}%
+**Progress:** {progress_bar}
+**Last Practiced:** {date_or_never}
+
+### Speaking 🗣️
+**Level:** {n}/5 {stars}
+**Accuracy:** {percent}%
+**Progress:** {progress_bar}
+**Last Practiced:** {date_or_never}
+
+### Vocabulary 📚
+**Level:** {n}/5 {stars}
+**Words Known:** {count}
+**Words Mastered:** {count}
+**Progress:** {progress_bar}
+**Last Practiced:** {date_or_never}
+
+### Reading 👀
+**Level:** {n}/5 {stars}
+**Comprehension:** {percent}%
+**Progress:** {progress_bar}
+**Last Practiced:** {date_or_never}
+
+---
+
+## 📈 Progress Trends
+
+### Accuracy Over Time
+{generate ASCII chart from progress-db weekly_summary}
+
+### This Week's Summary
+- **Sessions:** {count}
+- **Minutes:** {total}
+- **Exercises:** {count}
+- **Accuracy:** {percent}%
+- **Skills Practiced:** {list}
+
+---
+
+## 🎯 Focus Areas
+
+### 🔴 Critical (Needs Urgent Attention)
+{patterns from mistakes-db with mastery 0-1 and high frequency}
+
+### 🟡 Working On (Making Progress)
+{patterns from mistakes-db with mastery 2-3}
+
+### 🟢 Strong (Almost Mastered)
+{patterns from mistakes-db with mastery 4-5}
+
+---
+
+## 🔄 Spaced Repetition Status
+
+**Items Due Today:** {count}
+**Items Due This Week:** {count}
+**Items Mastered:** {count}
+
+---
+
+## 🏆 Achievements Unlocked
+
+{list from learner-profile → achievements, show locked ones with 🔒}
+
+---
+
+## 📅 Session History
+
+| Date | Duration | Skill | Accuracy |
+|------|----------|-------|----------|
+{most recent 5-10 sessions from session-log}
+
+---
+
+## 🎯 Next Goals
+
+**Short-term (This Week):**
+{derive from weak patterns + due reviews}
+
+**Medium-term (This Month):**
+{derive from skill mastery gaps}
+
+**Long-term:**
+{derive from target level gap}
+
+---
+
+## 💡 Recommendations
+
+1. {top weak area from mistakes-db}
+2. {skill not practiced recently}
+3. {due review count if > 0}
+
+---
+
+"{personalized motivational message}"
+```
+
+### 3. Optional interpretation footer
+
+Append this only if the learner seems new or asks what the numbers mean:
+
+```markdown
+## 📖 How to Read Your Stats
+
+**Mastery Levels:**
+- ⭐☆☆☆☆ (1/5): Just started
+- ⭐⭐☆☆☆ (2/5): Learning
+- ⭐⭐⭐☆☆ (3/5): Good
+- ⭐⭐⭐⭐☆ (4/5): Strong
+- ⭐⭐⭐⭐⭐ (5/5): Mastered
+
+**Accuracy bands:** 0-40% intensive, 40-60% learning, 60-75% good, 75-85% strong, 85%+ excellent.
+```
+
+## Examples
+
+### Example 1 — minimal (A1 learner, week 1)
+
+> # 📊 Mohammad's Dutch Learning Dashboard
+>
+> **Current Level:** A1 → A2 (4% to A2)
+> **Current Streak:** 🔥 3 days
+> **Total Sessions:** 3 · 45 min
+>
+> ### Vocabulary 📚
+> **Level:** 1/5 ⭐☆☆☆☆ · 12 words known · 0 mastered
+>
+> Speaking / Writing / Reading: Not yet practiced.
+>
+> **Items Due Today:** 6 — run `/review` first.
+>
+> "Three days in a row — momentum matters. Keep going!"
+
+### Example 2 — trigger on natural-language question
+
+Learner: "how am I doing on Dutch?" → auto-invoke this skill, render the full dashboard.
+
+## Critical Rules
+
+- **Read-only.** Never call `update-db.py` or edit any JSON in `data/`.
+- **Use the current streak value** from `learner-profile.json`. Never guess or increment.
+- **Use `day` vs `days`** correctly (1 = day, else days).
+- **Skip sections with no data.** If speaking hasn't been practiced, show "Not yet practiced" — don't fabricate numbers.
+- **Cite the learner by name** from `learner-profile.json`.
+- **Use target-language greetings** where natural (e.g. "Goed gedaan!" for Dutch).
+
+## Why This Skill Auto-Invokes
+
+Unlike session commands, this is a pure read. A false-positive (Codex opens the dashboard when the learner asked something else) costs only a few tokens — no DB corruption, no interrupted practice. Worth the lower trigger bar.

--- a/.agents/skills/progress/evals/evals.json
+++ b/.agents/skills/progress/evals/evals.json
@@ -1,0 +1,64 @@
+{
+  "skill_name": "progress",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "How am I doing with my Dutch?",
+      "expected_output": "A dashboard report rendered in the progress skill's canonical format — overview, skills mastery, trends, focus areas, spaced-repetition status, achievements, session history, next goals, recommendations. Must use the learner's name and the current streak value from learner-profile.json. No DB writes.",
+      "files": [],
+      "expectations": [
+        "The output contains the learner's name (from learner-profile.json)",
+        "The output contains the target language (from learner-profile.json)",
+        "The output contains the current streak value (day vs days rendered correctly)",
+        "The output contains a '💪 Skills Mastery' section with entries for writing, speaking, vocabulary, reading",
+        "The output contains a '🔄 Spaced Repetition Status' section with the due_reviews_count",
+        "The output does NOT call update-db.py",
+        "The output does NOT write to any file in data/"
+      ]
+    },
+    {
+      "id": 2,
+      "prompt": "/progress",
+      "expected_output": "Same dashboard as #1 — the explicit slash invocation should trigger the same canonical report.",
+      "files": [],
+      "expectations": [
+        "The output contains the learner's name",
+        "The output contains the target language",
+        "The output contains the current streak value",
+        "The output contains all 4 skill sections",
+        "The output does NOT call update-db.py"
+      ]
+    },
+    {
+      "id": 3,
+      "prompt": "show my stats",
+      "expected_output": "Dashboard report. 'show my stats' is a natural-language trigger that should auto-invoke this skill.",
+      "files": [],
+      "expectations": [
+        "The skill was triggered (output matches the dashboard template)",
+        "The output contains the learner's name",
+        "The output contains the current streak value"
+      ]
+    },
+    {
+      "id": 4,
+      "prompt": "can you teach me some Dutch vocabulary?",
+      "expected_output": "The progress skill should NOT trigger. This is a /vocab request, not a stats request.",
+      "files": [],
+      "expectations": [
+        "The progress-skill dashboard template is NOT rendered",
+        "The assistant routes the learner to /vocab or engages vocabulary practice"
+      ]
+    },
+    {
+      "id": 5,
+      "prompt": "what is the weather like today",
+      "expected_output": "The progress skill should NOT trigger. Unrelated to Fluent.",
+      "files": [],
+      "expectations": [
+        "The progress-skill dashboard template is NOT rendered",
+        "The assistant does not try to apply Fluent skills to an unrelated question"
+      ]
+    }
+  ]
+}

--- a/.agents/skills/reading/SKILL.md
+++ b/.agents/skills/reading/SKILL.md
@@ -1,0 +1,281 @@
+---
+name: reading
+description: Run an interactive reading comprehension session with a short target-language text followed by main-idea, detail, vocabulary-in-context, inference, and true/false questions. Triggered only when the learner types /reading. Presents the text, waits for the learner to read, then asks questions one at a time with immediate feedback, and optionally adds new vocabulary to the spaced-repetition queue.
+allowed-tools: Read, Write, Bash
+disable-model-invocation: true
+---
+
+# Reading Comprehension Session
+
+## Overview
+
+Present one text (100-500 words depending on level), ask 4-6 comprehension questions, extract vocabulary. Builds passive-to-active bridge: learners decode target-language writing, then answer questions that force recall.
+
+## When to Use
+
+Trigger this skill only when the learner types `/reading`. The skill is gated with `disable-model-invocation: true` — 15-20 min interactive session with DB writes should never start from an ambiguous prompt.
+
+Skip this skill below A1 mastery 3 — shorter flashcard drills (`/vocab`) are more appropriate for very early learners.
+
+## Instructions
+
+### 1. Load context
+
+```bash
+python3 .claude/hooks/read-db.py
+```
+
+Need: `learner-profile` (level, target language, interests), `mastery-db.skills_mastery.reading`.
+
+### 2. Opening
+
+```markdown
+# 👀 {target_language} Reading Practice
+
+Hallo {name}!
+
+Today we're practicing **reading comprehension**. I'll show you a short {target_language} text, then ask you questions about it.
+
+**Focus:** main ideas, details, vocabulary in context
+**Level:** {CEFR}
+**Duration:** 15-20 min
+
+**Tips:**
+- Read the whole text first
+- Don't translate every word — get the gist
+- Use context clues for unknown words
+- Read the questions before rereading the text
+
+**Ready? Let's read!** 📖
+```
+
+### 3. Pick text type + length
+
+A2 types (100-200 words): personal email, short news, advertisement, instructions, simple story, blog post, social media post, info leaflet.
+
+B1 (200-350 words): opinion pieces, longer narratives, structured guides.
+
+B2+ (350-500): editorials, technical explanations, interviews.
+
+Match the topic to `learner-profile.focus_areas` when possible.
+
+### 4. Present the text
+
+```markdown
+## 📄 Reading Text {N}
+
+**Topic:** {topic}
+**Type:** {text_type}
+**Length:** ~{word_count} words
+
+---
+
+{target-language text — clean formatting, no inline translation}
+
+---
+
+Take your time. When you're done, type **"ready"**.
+```
+
+### 5. Question sequence (one at a time)
+
+Rotate across these types:
+
+**Main idea:**
+```markdown
+## Vraag 1: Hoofdidee (main idea)
+
+{question in target language}
+
+a) {option 1}
+b) {option 2}
+c) {option 3}
+
+**Type a, b, or c:**
+```
+
+**Details:**
+```markdown
+## Vraag 2: Details
+
+{specific question about the text}
+
+**Type your answer:**
+```
+
+**Vocabulary in context:**
+```markdown
+## Vraag 3: Vocabulaire
+
+In the text it says "{word/phrase}". What does this mean?
+
+a) {meaning 1}
+b) {meaning 2}
+c) {meaning 3}
+```
+
+**Inference:**
+```markdown
+## Vraag 4: Begrijpen
+
+{question requiring inference — not directly stated}
+
+**Answer in {target language}:**
+```
+
+**True / false:**
+```markdown
+## Vraag 5: Waar of niet waar?
+
+{statement}
+
+**Type your answer:**
+```
+
+### 6. Feedback per question
+
+```markdown
+{✅ or ❌}
+
+**Answer:** {correct_answer}
+
+**Explanation:** {why — reference the text}
+
+{If incorrect: **The text says:** "{relevant_quote}"}
+
+**Score: {X}/10**
+
+---
+```
+
+### 7. Vocabulary review
+
+After the questions:
+
+```markdown
+## 📚 New Vocabulary from the Text
+
+| {target_language} | {native_language} | Example from text |
+|-------|---------|-------------------|
+| {word 1} | {meaning} | "{sentence}" |
+| {word 2} | {meaning} | "{sentence}" |
+
+**Save these for future review?** (They'll enter spaced repetition.)
+
+Type "yes" to add, "no" to skip.
+```
+
+If yes, stage each word for `new_vocabulary[]` in the end-of-session DB update.
+
+### 8. Session summary
+
+```markdown
+## 📊 Reading Session Complete!
+
+**Text:** {title/topic}
+**Length:** {words} words
+**Questions:** {N}
+**Accuracy:** {percent}%
+
+### Comprehension Breakdown
+- Main idea: {✅ or ❌}
+- Details: {score}
+- Vocabulary: {score}
+- Inference: {score}
+
+### New Words Added: {count}
+{list}
+
+### For Next Time
+- {suggestion based on which question type was weakest}
+
+**{target-language well done}!** 📖✨
+```
+
+### 9. Update all databases
+
+Use the `db-updater` skill:
+
+- `command_used: "/reading"`, `skills_practiced: ["reading"]`
+- `skill_scores.reading: {exercises: N, correct: count_right, time_minutes}`
+- `errors[]` — per question-type weakness (category `comprehension`, `vocabulary`, `inference`)
+- `new_vocabulary[]` — words the learner chose to save
+- `focus_next_session[]`
+
+Save to `/results/reading-session-{NNN}.md` — include the full text + Q&A for later analysis.
+
+## Examples
+
+### Example 1 — personal email text (Dutch A2)
+
+> ## 📄 Reading Text 1
+>
+> **Topic:** Making weekend plans
+> **Type:** Personal email
+> **Length:** ~75 words
+>
+> ---
+>
+> Beste Mohammad,
+>
+> Bedankt voor je email! Leuk dat je naar Amsterdam komt volgende maand. Ik heb tijd op zaterdag 15 maart. Zullen we om 14:00 uur afspreken bij het Centraal Station? We kunnen naar een café gaan en daarna door de stad wandelen.
+>
+> Het weer is meestal koud in maart, dus neem een warme jas mee! Ik verheug me erop om je te zien.
+>
+> Groetjes,
+> Lisa
+>
+> ---
+>
+> Take your time. When you're done, type **"ready"**.
+
+### Example 2 — main-idea question on the above
+
+> ## Vraag 1: Hoofdidee
+>
+> Waar gaat deze email over?
+>
+> a) Lisa is op vakantie in Iran.
+> b) Lisa en Mohammad maken plannen voor een ontmoeting.
+> c) Lisa vraagt naar het weer.
+
+Learner: "b"
+
+> ✅ Correct!
+>
+> **Answer:** b) Lisa en Mohammad maken plannen voor een ontmoeting.
+>
+> **Explanation:** The email's core is the meetup plan — date, time, place, and activity. The weather is a secondary detail.
+>
+> **Score: 10/10**
+
+## Critical Rules
+
+- **Wait for "ready"** before asking the first question. Rushing the reading step defeats the purpose.
+- **One question at a time.** Multiple at once invites skimming.
+- **Ask questions in the target language** (at least from A2 up). Reading-comprehension checks should happen in the same language as the text.
+- **Quote the text** in explanations so the learner can trace the answer back to the source.
+- **Vocabulary opt-in.** Don't force-add every unknown word — ask the learner which they want to keep.
+- **Never auto-invoke.** Gated; must fire only on explicit `/reading`.
+
+## Sample Text Bank (Dutch A2)
+
+### Advertisement
+```
+CURSUS NEDERLANDS VOOR BEGINNERS
+
+Wil je Nederlands leren? Start deze maand nog!
+
+- Kleine groepen (max 8 personen)
+- Ervaren docenten
+- 2x per week, 's avonds
+- Locatie: Centrum Amsterdam
+- Prijs: €150 per maand
+
+Aanmelden kan via email: info@nederlandscursus.nl
+Bel voor meer informatie: 020-123-4567
+
+Eerste les gratis!
+```
+
+Keep a small bank per target language — don't reuse the same text in consecutive sessions.

--- a/.agents/skills/review/SKILL.md
+++ b/.agents/skills/review/SKILL.md
@@ -1,0 +1,221 @@
+---
+name: review
+description: Run today's spaced-repetition review queue — items scheduled by SM-2 that need reinforcement before the learner forgets them. Triggered only when the learner types /review. Pulls due items from spaced-repetition.review_queue.today, generates a targeted exercise for each, evaluates the response, updates SM-2 parameters, and reshelves items into the correct future queue.
+allowed-tools: Read, Write, Bash
+disable-model-invocation: true
+---
+
+# Spaced-Repetition Review Session
+
+## Overview
+
+Replay items the learner learned before, timed so they hit just before the forgetting curve drops them. This is the single most effective session type — the system depends on it running daily. Items the learner gets right get pushed further into the future; items they miss come back tomorrow.
+
+## When to Use
+
+Trigger this skill only when the learner types `/review`. The skill is gated with `disable-model-invocation: true` — mutating SM-2 state from a misread prompt would cascade through every future session.
+
+Skip this skill when the queue is empty — suggest `/vocab` or `/learn` instead.
+
+## Instructions
+
+### 1. Load review queue
+
+```bash
+python3 .claude/hooks/read-db.py
+```
+
+Read `spaced-repetition.review_queue.today` and `daily_limits.review_items_per_day`. Sort items by `priority` (critical → high → medium → low). Cap at the daily limit (usually 20).
+
+If the queue is empty:
+
+```markdown
+🎉 No reviews due today! Your spaced repetition is up to date.
+
+Want to practice something new? Try:
+- `/learn` — adaptive mixed practice
+- `/vocab` — learn new words
+- `/progress` — see your stats
+```
+
+### 2. Opening
+
+```markdown
+# 🔄 Today's Spaced Repetition Review
+
+Hallo {name}! Time to review items your brain is about to forget. This keeps everything fresh. 🧠
+
+**Items Due Today:** {count}
+**Estimated Time:** ~{minutes} min
+
+Why review? Spaced repetition prevents forgetting, moves items into long-term memory, and builds automaticity.
+
+**Ready? Let's start!** 💪
+```
+
+### 3. Generate exercise per item
+
+Each item has:
+
+```json
+{
+  "item_id": "...",
+  "item_type": "error_pattern | vocabulary | grammar_rule",
+  "easiness_factor": 2.5,
+  "interval_days": 6,
+  "repetitions": 2,
+  "due_date": "YYYY-MM-DD",
+  "priority": "critical | high | medium | low",
+  "content": "...",
+  "answer": "..."
+}
+```
+
+Generate an exercise matched to `item_type`:
+
+- **error_pattern**: load the pattern from `mistakes-db`, create a scenario that forces the correct form. E.g. `formal_informal_confusion` → ask the learner to complete a formal email opening.
+- **vocabulary**: recognition (target → native), production (native → target), or cloze — rotate modes.
+- **grammar_rule**: a fill-in or error-correction exercise that tests the rule.
+
+Present one at a time:
+
+```markdown
+## Review {N}/{total} — {priority emoji}
+
+**Type:** {item_type}
+**Last reviewed:** {X} days ago
+**Current mastery:** {stars}
+
+{exercise}
+
+**Type your answer:**
+```
+
+### 4. Evaluate + update SM-2
+
+Use the `feedback-formatter` skill for per-answer feedback.
+
+Then stage the item for the end-of-session update. Do NOT hand-edit `spaced-repetition.json` — use `review_results[]` in the `db-updater` payload:
+
+```json
+{ "item_id": "vocab_huis", "quality": 4 }
+```
+
+The `update-db.py` script runs the SM-2 math (see `sm2-calculator` skill) and rebuilds the queue. Mapping: `quality = floor(score / 2)`.
+
+### 5. Progress pulse every 5 items
+
+```markdown
+## Progress Update
+
+**Reviewed:** {N}/{total}
+**Accuracy:** {percent}%
+**Time Remaining:** ~{min} min
+
+Keep going! 💪
+```
+
+### 6. Session summary
+
+```markdown
+## 🎉 Review Session Complete!
+
+**Reviewed:** {count}
+**Accuracy:** {percent}%
+**Time:** {min} min
+
+### Breakdown
+
+**Mastered (no mistakes):** {count} — won't appear again for a while 🎉
+**Good (minor slips):** {count} — next in {X} days
+**Need more practice:** {count} — tomorrow again
+
+### Next Review Schedule
+- Tomorrow: {count}
+- This week: {count}
+- Next week: {count}
+
+**Streak:** 🔥 {X} {day/days} 🔥
+
+**Tip:** {one line of advice based on accuracy}
+
+{target-language well done}! 🌟
+```
+
+### 7. Update all databases
+
+Use the `db-updater` skill:
+
+- `command_used: "/review"`, `skills_practiced: [derived from reviewed items]`
+- `skill_scores` — aggregate per skill touched
+- `review_results[]` — every item reviewed, with `quality`
+- `errors[]` — only patterns where the learner got it wrong (bumps frequency)
+- `focus_next_session[]` — the 2-3 items with lowest quality this session
+
+Save exchange to `/results/review-session-{NNN}.md` for later analysis.
+
+## Examples
+
+### Example 1 — vocabulary review with wrong answer
+
+> ## Review 3/12 — 🔴
+>
+> **Type:** vocabulary
+> **Last reviewed:** 6 days ago
+> **Current mastery:** ⭐⭐⭐☆☆
+>
+> **Dutch:** het raam
+>
+> **What does it mean in English?**
+
+Learner: "the door"
+
+> ❌ Close — those are both openings in a wall, but not the same.
+>
+> **Corrections:**
+> - 🟡 "the door" → **"the window"** (vocabulary — `het raam` is window; `de deur` is door)
+>
+> **Correct version:**
+> "het raam" = the window.
+>
+> **Score: 3/10** 💪 Easy to mix — we'll review this again soon.
+>
+> (Logged: `review_results[]` item quality=1 → `interval_days=1, repetitions=0`, stays in today's queue.)
+
+### Example 2 — correct answer with mastery bump
+
+> ## Review 7/12 — 🟡
+>
+> **Type:** grammar_rule
+> **Last reviewed:** 14 days ago
+> **Current mastery:** ⭐⭐⭐⭐☆
+>
+> **Complete:** "Ik schrijf u omdat ik ____ kan komen." (reason: can't come)
+
+Learner: "niet"
+
+> ✅ Perfect — omdat-clause word order locked in.
+>
+> **Answer:** "Ik schrijf u omdat ik niet kan komen."
+>
+> **Score: 10/10** 🎯
+>
+> (Logged: quality=5 → `interval_days = round(14 * EF)`, queue: `later`. `consecutive_correct` = 5, mastery → 5 ⭐⭐⭐⭐⭐.)
+
+## Critical Rules
+
+- **Daily.** The whole system assumes the learner runs `/review` every day. Missing a day breaks the intended spacing.
+- **Never auto-invoke.** Gated; must fire only on explicit `/review`. Long interactive + SM-2 mutation.
+- **One item at a time.** Rushing = false positives.
+- **Let the learner struggle.** If they don't remember, that's useful data (quality 0-2). The algorithm needs honest signals.
+- **Never hand-edit `spaced-repetition.json`.** Queue is rebuilt on every `update-db.py` call.
+
+## What the Schedule Means
+
+Tell the learner if they ask:
+
+- 1 day — new or struggling items
+- 2-3 days — learning, building strength
+- 1 week — getting comfortable
+- 2+ weeks — strong, maintenance only
+- 1+ month — mastered, long-term memory

--- a/.agents/skills/session-analyzer/SKILL.md
+++ b/.agents/skills/session-analyzer/SKILL.md
@@ -1,0 +1,141 @@
+---
+name: session-analyzer
+description: Parse Fluent `/results/*.md` session files to extract error patterns, strengths, accuracy trends, and focus areas for the next session. Use when the tutor needs to analyze the learner's recent performance — planning the next lesson, recommending focus areas, or answering "what should I practice next?".
+---
+
+# Session Analyzer
+
+## Overview
+
+Every practice session writes a markdown report to `/results/{skill}-session-{ID}.md` (e.g. `writing-session-012.md`). This skill describes how to read those files to plan adaptive follow-up practice. Use it when the tutor needs narrative context the JSON databases don't capture — the exact sentence the learner wrote, the scenario, the feedback they received.
+
+## When to Use
+
+Load this skill whenever the tutor:
+
+- Plans today's focus before `/learn`, `/writing`, etc.
+- Answers the learner's question "what's my weakest area" or "what should I work on".
+- Generates the next session plan.
+
+Skip this skill when aggregated JSON numbers are enough — prefer `read-db.py` for counts, trends, and mastery levels. Use this skill only when the textual context matters.
+
+## Instructions
+
+### 1. Find recent session files
+
+```
+/results/{skill}-session-{ID}.md
+```
+
+File naming: `{skill}-session-{NNN}.md` keeps files grouped by skill + chronological by ID. Read the most recent 3-5 files of the relevant skill; don't re-read the entire history.
+
+### 2. Extract error patterns
+
+Scan for `❌` markers. Each correction has:
+
+- The wrong form ("Your answer")
+- The correct form
+- A category (grammar, formal_informal, vocabulary, prepositions, articles, spelling, missing)
+- A severity (🔴 critical, 🟡 moderate, 🟢 minor)
+
+Count frequency per pattern across recent files:
+
+- **1 occurrence** — possibly a typo, ignore
+- **2-3** — emerging pattern, worth drilling
+- **4+** — critical weakness, highest priority
+
+### 3. Extract strengths
+
+Scan for `✅` markers and scores ≥ 7/10. Note consistent correct usage — these are reinforcement targets, not drill targets.
+
+### 4. Track trajectory
+
+Across sessions, track:
+
+- Overall accuracy per session
+- Critical vs moderate vs minor error counts
+- Writing speed (words per minute, if tracked)
+
+### 5. Plan the next session
+
+Based on the analysis:
+
+1. **Top 3 critical weaknesses** (highest frequency + severity) → 50% of session time.
+2. **Top 2 moderate patterns** → 30% of session time.
+3. **One full integration scenario** → 20% of session time.
+
+Plan template:
+
+```markdown
+## Session {N} Plan ({X} min)
+
+**Top 3 Weaknesses:**
+1. {pattern} — {count} occurrences, severity {emoji}
+2. ...
+
+**Strengths to Reinforce:**
+- {skill}
+
+**Drill Sequence:**
+1. Warm-up ({x} min) — quick wins on known patterns
+2. Targeted drill 1 ({y} min) — focus on weakness #1
+3. Targeted drill 2 ({y} min) — focus on weakness #2
+4. Mixed integration ({z} min) — combine all patterns
+5. Full scenario ({w} min) — exam-style task
+```
+
+### 6. Tune difficulty
+
+Use recent session accuracy to tune today's difficulty:
+
+- **<50%** → simplify, add scaffolding, smaller chunks
+- **50-70%** → correct zone, keep going
+- **>70%** → raise difficulty, introduce new patterns
+
+## Examples
+
+### Example 1 — error summary table
+
+```markdown
+## Error Pattern Summary (last 3 sessions)
+
+| Category | Pattern | Session Count | Total Count | Severity | Example |
+|----------|---------|---------------|-------------|----------|---------|
+| formal_informal | Using "je" in formal context | 2 | 5 | 🔴 | "Ik schrijf je" → "Ik schrijf u" |
+| grammar | Wrong "omdat" clause order | 1 | 3 | 🟡 | "omdat ik kan niet" → "omdat ik niet kan" |
+| prepositions | "om" vs "op" | 2 | 4 | 🟡 | "op 10:00 uur" → "om 10:00 uur" |
+```
+
+### Example 2 — trajectory + plan
+
+```markdown
+## Trajectory (writing, last 3)
+
+| Session | Date | Accuracy | Critical | Moderate | Minor |
+|---------|------|----------|----------|----------|-------|
+| 010 | 2026-04-20 | 60% | 3 | 4 | 2 |
+| 011 | 2026-04-22 | 68% | 2 | 3 | 3 |
+| 012 | 2026-04-23 | 74% | 1 | 2 | 3 |
+
+Trend: accuracy rising ~7% per session. Critical errors halving each session — keep the focus on formal_informal + omdat clauses.
+
+## Next Session Plan (20 min)
+
+**Top weaknesses:** formal_informal (5 occurrences total), omdat word order (3).
+**Strength:** vocabulary recall on household nouns.
+
+1. Warm-up (3 min) — 5 quick household-noun recognition drills.
+2. Targeted drill 1 (7 min) — 5 formal-email sentence completions forcing "u".
+3. Targeted drill 2 (5 min) — 4 omdat-clause reorderings.
+4. Integration (5 min) — write a 40-word formal email combining both patterns.
+```
+
+## Critical Rules
+
+- **Read `/results/` markdown for context.** Use `read-db.py` for numerical summaries — don't reimplement counts by re-parsing markdown when the DB already has them.
+- **Cap the look-back window.** 3-5 recent sessions for the relevant skill. Older data is already baked into `mistakes-db.json` mastery levels.
+- **Never alter `/results/` files.** They are immutable records. Planning only.
+
+## Why This Matters
+
+Pattern analysis turns raw session records into an adaptive curriculum. Without it, every session looks the same regardless of progress. With it, tomorrow's drills target yesterday's weakest spots — that's the whole point of the system.

--- a/.agents/skills/setup/SKILL.md
+++ b/.agents/skills/setup/SKILL.md
@@ -1,0 +1,250 @@
+---
+name: setup
+description: One-time interactive onboarding that creates the learner's personalized language-learning profile — name, target language, native language, current/target CEFR level, timeline, daily minutes, and learning goals. Triggered only when the learner types /setup. Also handles profile updates and resets for returning users. Must never auto-invoke because re-running can reset progress.
+allowed-tools: Read, Write, Bash, AskUserQuestion
+disable-model-invocation: true
+---
+
+# Language Learning Setup
+
+## Overview
+
+One-time onboarding that seeds all 6 databases in the Fluent data directory. After setup, every other skill reads from those files — this is the bootstrap. Also handles profile updates and progress resets for returning users.
+
+The data directory is resolved at runtime (not hardcoded to `./data/`):
+
+1. `$FLUENT_DATA_DIR` if set
+2. `$CLAUDE_PROJECT_DIR/data/` if that path contains `learner-profile.json` (clone mode)
+3. `./data/` if `./data/learner-profile.json` exists (clone mode, cwd inside repo)
+4. `~/.codex/fluent-data/` otherwise (plugin-install default)
+
+Always resolve it via the helper rather than writing literal `data/` paths:
+
+```bash
+FLUENT_DATA="$(python3 "${CLAUDE_PLUGIN_ROOT:-${CLAUDE_PROJECT_DIR:-.}}/.claude/hooks/ensure_data_dir.py")"
+```
+
+or from Python:
+
+```python
+import sys
+sys.path.insert(0, f"{PLUGIN_ROOT}/.claude/hooks")
+from fluent_paths import ensure_data_dir
+DATA = ensure_data_dir()
+```
+
+## When to Use
+
+Trigger this skill only when the learner types `/setup`. The skill is gated with `disable-model-invocation: true` — re-running can reset a learner's progress, so it must never auto-fire from an ambiguous prompt.
+
+Skip this skill if a profile already exists and the learner did not ask to change anything; route them to `/learn` or `/progress` instead.
+
+## Instructions
+
+### 1. Check for existing profile
+
+Resolve the data directory first, then probe for `learner-profile.json`:
+
+```bash
+DATA_DIR="$(python3 -c "
+import sys; sys.path.insert(0, '${CLAUDE_PLUGIN_ROOT:-${CLAUDE_PROJECT_DIR:-.}}/.claude/hooks')
+from fluent_paths import data_dir
+print(data_dir())
+")"
+test -f "$DATA_DIR/learner-profile.json" && echo "exists" || echo "new"
+```
+
+If it exists, jump to **Profile updates** below. Otherwise continue.
+
+### 2. Welcome
+
+```markdown
+# 🌍 Welcome to Your Personal Language Learning System!
+
+This AI-powered system will help you learn any language through:
+- 📊 Systematic progress tracking
+- 🧠 Spaced repetition (scientifically proven)
+- 🎮 Gamification (streaks, achievements)
+- 📈 Adaptive difficulty
+- 🎯 Personalized to YOUR goals
+
+**Let's get you set up!** (~5 minutes)
+```
+
+### 3. Collect info
+
+Use the `AskUserQuestion` tool to gather questions in batches when possible. Required fields:
+
+1. **Name** — personalizes greetings.
+2. **Target language** — the language being learned (e.g. Spanish, French, German, Japanese, Korean, Arabic, Dutch).
+3. **Native language** — for translations and explanations.
+4. **Other languages spoken** — optional, used to offer cross-language connections.
+5. **Current level** — A1 / A2 / B1 / B2 / C1 / C2 / "not sure".
+6. **Target level** — where they want to get to.
+7. **Timeline** — 3 months / 6 months / 12 months / 2+ years / custom.
+8. **Daily study minutes** — 10 / 15 / 30 / 60 / custom.
+9. **Learning goal** — travel / work / exam (specify) / living in country / academic / family / interest.
+10. **Learning style** — conversational / academic / immersive / balanced (default).
+11. **Gamification on/off** — default on.
+
+If the learner picks "not sure" for current level, run a quick 5-question assessment:
+
+1. Basic vocabulary recognition → A1
+2. Simple sentence construction → A2
+3. Past tense usage → B1
+4. Complex subordinate clauses → B2
+5. Idiomatic expression → C1
+
+Map score to level: 0-1 correct = A1, 2 = A2, 3 = B1, 4 = B2, 5 = C1.
+
+### 4. Generate the learning plan
+
+Compute expected months to target level:
+
+```
+A1 → A2: ~100 hours
+A2 → B1: ~150 hours
+B1 → B2: ~200 hours
+B2 → C1: ~300 hours
+C1 → C2: ~400 hours
+
+months = hours_needed / (daily_minutes / 60) / 30
+```
+
+Adjust:
+
+- `-10%` time if learner's native language is typologically close to the target (e.g. Dutch ↔ English, Spanish ↔ Italian).
+- `-10%` per additional language already known (cap at 30% total).
+
+Present:
+
+```markdown
+## 🎉 Setup Complete!
+
+**Your Learning Profile:**
+- 👤 Name: {name}
+- 🌍 Learning: {target_language}
+- 📚 Native: {native_language}
+- 📊 Level: {current} → {target}
+- 📅 Timeline: {timeline}
+- ⏱️ Daily time: {minutes} min
+- 💡 Goal: {goal}
+
+## 📋 Personalized Plan
+
+**Estimated time:** {months} months
+**Total study hours:** ~{hours} hours
+
+### Weekly Schedule
+**Daily:**
+- 🔄 `/review` — spaced repetition ({X} min)
+- 📚 `/vocab` — new vocabulary ({Y} min)
+
+**Alternating:**
+- 📝 `/writing` (Mon/Wed/Fri)
+- 🗣️ `/speaking` (Tue/Thu/Sat)
+- 📖 `/reading` (Sun)
+
+**Weekly:**
+- 📊 `/progress` — check stats (5 min)
+
+### Milestones
+- Month 1: {reasonable short-term}
+- Month 3: {quarter-way}
+- Month 6: {half-way}
+- Target date: {target_level}!
+
+### Next Steps
+1. Start now — type `/learn`
+2. Daily habit — `/review` every day
+3. Weekly — `/progress` to see stats
+4. Stay consistent — even 10 min daily beats 2 hours weekly
+
+**Your journey to {target_language} fluency starts now!** 🚀
+```
+
+### 5. Write databases
+
+Start from the templates in `data-examples/`. Resolve the target directory via `fluent_paths.ensure_data_dir()` (it creates the directory if missing), then create these 6 files inside it:
+
+- `learner-profile.json` — fill all fields from the interview.
+- `progress-db.json` — empty stats.
+- `mistakes-db.json` — empty `error_patterns`.
+- `mastery-db.json` — `skills_mastery` entries with `mastery_level: 0` for each skill.
+- `spaced-repetition.json` — empty queues, `daily_limits.review_items_per_day: 20`.
+- `session-log.json` — empty `sessions` array, `total_sessions: 0`.
+
+Use the Write tool for each. Do not call `update-db.py` — that script is for session updates, not bootstrapping.
+
+### 6. Optional first lesson
+
+```markdown
+## 🎓 Want to start your first lesson now?
+
+A quick 5-10 min intro session to learn your first 10 words and get familiar with the system.
+
+Type "yes" to start, "later" to begin on your own.
+```
+
+If yes, hand off to the `learn` skill.
+
+## Profile Updates (existing profile)
+
+```markdown
+# 👋 Welcome back, {name}!
+
+You already have a learning profile.
+
+What would you like to do?
+
+1. **Update profile** — change goals, timeline, or preferences
+2. **View current plan** — see your learning schedule
+3. **Reset progress** — start fresh (⚠️ erases all progress!)
+4. **Cancel** — keep everything as is
+
+**Type 1, 2, 3, or 4:**
+```
+
+- **1** — ask which field, update only that field, preserve the rest.
+- **2** — render the plan section from current data. Read-only.
+- **3** — confirm twice. This deletes every file in the resolved data directory. Back up first:
+
+  ```bash
+  DATA_DIR="$(python3 -c "
+  import sys; sys.path.insert(0, '${CLAUDE_PLUGIN_ROOT:-${CLAUDE_PROJECT_DIR:-.}}/.claude/hooks')
+  from fluent_paths import data_dir
+  print(data_dir())
+  ")"
+  TS="$(date +%Y%m%d-%H%M%S)"
+  mkdir -p "$DATA_DIR/.backups/pre-reset-$TS"
+  cp "$DATA_DIR"/*.json "$DATA_DIR/.backups/pre-reset-$TS/"
+  ```
+
+  Then restart setup from Step 2.
+- **4** — exit cleanly.
+
+## Examples
+
+### Example 1 — first-time setup flow
+
+Learner runs `/setup`. After collecting all 11 answers, compute months, generate plan, write 6 JSON files, offer first lesson.
+
+### Example 2 — returning-user profile reset
+
+Learner: "reset my progress, I want to start over"
+
+> You're about to delete:
+> - 42 sessions
+> - 6-day streak
+> - 287 vocabulary items
+> - 12 mastered patterns
+>
+> This is irreversible. Type `RESET` (all caps) to confirm, or anything else to cancel.
+
+## Critical Rules
+
+- **Never auto-invoke.** Re-running this can reset a learner's progress. Must be an explicit `/setup`.
+- **Confirm twice before reset.** "This will erase X days of progress, Y sessions, and Z mastered words. Proceed? (yes/no)".
+- **Always seed all 6 files** — every other skill assumes they exist.
+- **Back up before reset.** Hooks may not fire here; back up manually to `.backups/pre-reset-<timestamp>/`.
+- **Don't invent data.** Start every file empty — progress, mistakes, mastery all start at zero. The system builds up from real sessions.

--- a/.agents/skills/sm2-calculator/SKILL.md
+++ b/.agents/skills/sm2-calculator/SKILL.md
@@ -1,0 +1,133 @@
+---
+name: sm2-calculator
+description: SM-2 spaced-repetition algorithm reference for the Fluent language learning system. Use whenever the tutor schedules the next review of a vocabulary item, grammar rule, or error pattern — i.e. after every answered review question. Defines the 0-5 quality scale, interval formula, easiness-factor update, and mastery-level transitions that keep the spaced-repetition database correct.
+---
+
+# SM-2 Calculator
+
+## Overview
+
+Fluent uses SM-2 (SuperMemo 2) to decide when the learner next sees an item. This skill is the single source of truth for the algorithm. Every practice skill updates `<data_dir>/spaced-repetition.json` (where `<data_dir>` is resolved by `fluent_paths.data_dir()`) through these rules after each answered question.
+
+## When to Use
+
+Load this skill whenever the tutor:
+
+- Grades a review-queue item and must compute its next due date.
+- Maps a 0-10 score to an SM-2 quality.
+- Updates `easiness_factor`, `interval_days`, `repetitions`, or `mastery_level` on a spaced-repetition item.
+- Decides which queue (`today` / `tomorrow` / `this_week` / `later`) to place an item in.
+
+Skip this skill when the `db-updater` skill is already being used — the `update-db.py` script runs SM-2 internally.
+
+## Instructions
+
+### 1. Convert score to quality
+
+| Score | Quality | Meaning |
+|-------|---------|---------|
+| 10/10 | 5 | Perfect, instant recall |
+| 8-9   | 4 | Correct after hesitation |
+| 6-7   | 3 | Correct with difficulty |
+| 4-5   | 2 | Incorrect but remembered when shown |
+| 2-3   | 1 | Incorrect, familiar |
+| 0-1   | 0 | Complete blackout |
+
+Rule: `quality = floor(score / 2)`.
+
+### 2. Update interval
+
+```
+if quality >= 3:   # correct
+    if repetitions == 0:
+        interval = 1
+    elif repetitions == 1:
+        interval = 6
+    else:
+        interval = round(previous_interval * easiness_factor)
+    repetitions += 1
+else:              # incorrect
+    interval = 1
+    repetitions = 0
+```
+
+### 3. Update easiness factor
+
+Apply after every answer:
+
+```
+EF_new = EF + (0.1 - (5 - quality) * (0.08 + (5 - quality) * 0.02))
+EF_new = max(1.3, EF_new)
+```
+
+### 4. Update mastery level
+
+Track `consecutive_correct` and `consecutive_incorrect` per item:
+
+```
+if consecutive_correct >= 5:
+    mastery_level = min(5, mastery_level + 1)
+    consecutive_correct = 0
+elif consecutive_incorrect >= 3:
+    mastery_level = max(0, mastery_level - 1)
+    consecutive_incorrect = 0
+```
+
+### 5. Update per-item fields
+
+After each answer, the item in `spaced-repetition.json` must have:
+
+- `easiness_factor` — updated via formula
+- `interval_days` — new interval
+- `repetitions` — incremented or reset
+- `consecutive_correct` / `consecutive_incorrect` — one incremented, the other reset
+- `total_reviews` — incremented
+- `mastery_level` — possibly changed
+- `due_date` — `today + interval_days` (YYYY-MM-DD)
+- `last_reviewed` — today
+
+### 6. Route to correct queue
+
+After updating:
+
+- `interval_days == 1` → `review_queue.tomorrow`
+- `interval_days <= 7` → `review_queue.this_week`
+- `interval_days > 7` → `review_queue.later`
+
+If the learner got it wrong (quality < 3), keep the item in `review_queue.today` so it reappears in the same session.
+
+### 7. Preferred implementation
+
+Do not hand-edit `spaced-repetition.json`. Call `.claude/hooks/update-db.py` with a `review_results` array — the script runs SM-2 atomically and rebuilds the queue. Only do manual math when the script is unavailable. See the `db-updater` skill for the payload schema.
+
+```bash
+python3 .claude/hooks/update-db.py <<'EOF'
+{
+  "session_id": "session-NNN",
+  "date": "YYYY-MM-DD",
+  "review_results": [
+    { "item_id": "vocab_huis", "quality": 4 }
+  ]
+}
+EOF
+```
+
+## Examples
+
+See `.claude/references/sm2-worked-examples.md` for 4 worked examples covering: correct answer (regular case), wrong answer (reset + EF drop), 5th consecutive correct (mastery bump), 3rd consecutive wrong (mastery drop). Each example shows the full before/after state.
+
+Quick version:
+
+- Correct, q=4: `interval = round(prev * EF)`, `repetitions += 1`, EF barely moves.
+- Wrong, q<3: `interval = 1`, `repetitions = 0`, EF drops sharply, item stays in today's queue.
+
+## Critical Rules
+
+- **Floor EF at 1.3.** Never let the easiness factor drop lower — rounds to infinite daily reviews.
+- **Reset repetitions on wrong answer.** The item returns to the start of the learning sequence.
+- **Do not hand-tune intervals.** Trust the algorithm. Shortcuts break long-term retention.
+- **Prefer `update-db.py`.** Only reimplement this math when the script is unavailable.
+
+## Why This Matters
+
+SM-2 reviews items just before the learner forgets them, maximizing long-term retention per minute of practice. Wrong scheduling means wasted reviews (too early) or forgotten items (too late). The whole Fluent system rests on these numbers being correct.

--- a/.agents/skills/speaking/SKILL.md
+++ b/.agents/skills/speaking/SKILL.md
@@ -1,0 +1,234 @@
+---
+name: speaking
+description: Run an interactive typed conversation session simulating spoken practice — free-flowing dialogue, role-plays, and opinion questions prioritizing communication over perfect grammar. Triggered only when the learner types /speaking. Asks questions one at a time in the target language, evaluates clarity and naturalness first and grammar second, and updates all databases at the end.
+allowed-tools: Read, Write, Bash
+disable-model-invocation: true
+---
+
+# Speaking Practice (Typed)
+
+## Overview
+
+Conversational practice through typed dialogue. Unlike `/writing`, prioritize **communication and naturalness** — grammar errors that don't block meaning are downplayed. Goal: build the learner's confidence to produce target-language output without over-analyzing.
+
+## When to Use
+
+Trigger this skill only when the learner types `/speaking`. The skill is gated with `disable-model-invocation: true` — 15-20 min interactive session with DB writes should never start from an ambiguous prompt.
+
+Skip this skill below A1 mastery 2 — the learner needs a basic word bank and verb conjugations first (run `/vocab` a few times).
+
+## Instructions
+
+### 1. Load context
+
+```bash
+python3 .claude/hooks/read-db.py
+```
+
+Need: `learner-profile` (level, target language), `mastery-db.skills_mastery.speaking`.
+
+### 2. Opening
+
+```markdown
+# 🗣️ {target_language} Speaking Practice
+
+Hallo {name}!
+
+Today we're practicing **speaking** through typed conversation. I'll ask you questions or give scenarios, you respond naturally in {target_language} — just like a real conversation.
+
+**Focus:** natural expression, fluency, pronunciation (typed)
+**Level:** {CEFR}
+**Duration:** 15-20 min
+
+**Tips:**
+- Think in {target_language}, not {native_language}
+- Don't chase perfect grammar — focus on getting your message across
+- Use complete sentences
+- Be natural and conversational
+
+**Ready? Let's chat!** 💬
+```
+
+### 3. Pick topic based on mastery
+
+A2 topics:
+1. Personal introductions
+2. Daily routine
+3. Hobbies and interests
+4. Shopping
+5. Making appointments
+6. Asking for directions
+7. Ordering food
+8. Talking about weather
+9. Weekend plans
+10. Work / study
+
+B1+: opinions, comparisons, hypotheticals, complaints, narratives.
+
+### 4. One question at a time
+
+```markdown
+## Question {N}: {Topic}
+
+{Question in target language}
+
+**Type your answer in {target_language}:**
+```
+
+Build the conversation naturally — after 3-4 Qs on one topic, transition: `Interessant! Let's talk about something else...`.
+
+### 5. Evaluate
+
+Check in this order:
+
+1. **Communication** (most important, 0-5 points): was the message clear? Did it answer the question?
+2. **Grammar** (0-3 points): verb conjugation, word order, articles. Note but don't belabor.
+3. **Vocabulary** (0-2 points): appropriate word choice, no English mixing.
+
+Feedback template (variant of `feedback-formatter`):
+
+```markdown
+{✅ or 🟡} {one-line encouragement}
+
+**What you said:**
+"{their_answer}"
+
+**Communication:** {Clear / Mostly clear / Unclear} ✅
+
+**Grammar notes:** (secondary — don't over-focus)
+- {major error → correction, only if communication-blocking}
+
+**Natural alternative:**
+You could also say: "{more_natural_phrasing}"
+
+**Score: {X}/10**
+- Communication: {Y}/5
+- Grammar: {Z}/3
+- Vocabulary: {W}/2
+
+{encouragement}
+
+---
+```
+
+### 6. Role-play (advanced)
+
+For B1+ or when the learner is warmed up:
+
+```markdown
+## 🎭 Role-Play
+
+**Scenario:** {description in native language}
+**Your role:** {what the learner plays}
+**I'll be:** {what Codex plays}
+
+Ready? I'll start...
+
+---
+
+{first line in target language}
+
+**Your turn:**
+```
+
+### 7. Session summary
+
+```markdown
+## 🎉 Speaking Session Complete!
+
+**Duration:** {X} min
+**Questions Answered:** {N}
+**Topics Covered:** {list}
+
+### Communication Scores
+**Overall:** {percent}%
+- Clear messages: {count}
+- Natural expression: {rating}/5
+- Confidence: Growing! 💪
+
+### Vocabulary Used Well
+- {words}
+
+### For Next Time
+- Try using: {new phrase}
+- Practice: {weak area}
+
+**{target-language well done}!** 🌟
+```
+
+### 8. Update all databases
+
+Use the `db-updater` skill:
+
+- `command_used: "/speaking"`, `skills_practiced: ["speaking"]`
+- `skill_scores.speaking: {exercises: N, correct: count_of_clear_answers, time_minutes}`
+- `errors[]` — only communication-blocking ones (don't flood mistakes-db with minor speaking slips)
+- `focus_next_session[]` — one topic + one pattern
+
+Save exchange to `/results/speaking-session-{NNN}.md`.
+
+## Examples
+
+### Example 1 — personal intro (Dutch A2)
+
+> ## Question 1: Introductions
+>
+> Vertel me over jezelf. Waar kom je vandaan?
+> (Tell me about yourself. Where are you from?)
+
+Learner: "Ik ben Mohammad. Ik kom van Iran maar ik woon nu in Nederland."
+
+> ✅ Clear and natural!
+>
+> **What you said:** "Ik ben Mohammad. Ik kom van Iran maar ik woon nu in Nederland."
+>
+> **Communication:** Clear ✅
+>
+> **Grammar notes:**
+> - 🟢 "van Iran" → **"uit Iran"** (prepositions — origin uses `uit`, not `van`). Small slip; message still crystal clear.
+>
+> **Natural alternative:**
+> "Ik kom uit Iran, maar ik woon al een paar jaar in Nederland."
+>
+> **Score: 9/10**
+> - Communication: 5/5
+> - Grammar: 2/3
+> - Vocabulary: 2/2
+>
+> Great start — you packed two ideas into one sentence, which is exactly what fluency looks like.
+
+### Example 2 — role-play opener (café scenario)
+
+> ## 🎭 Role-Play
+>
+> **Scenario:** You're at a café in Amsterdam. You want coffee and a vegetarian option for lunch.
+> **Your role:** Customer
+> **I'll be:** The server
+>
+> ---
+>
+> *"Goedemiddag! Wat wilt u drinken?"*
+>
+> **Your turn:**
+
+## Critical Rules
+
+- **Communication first.** A clear message with a missed article scores better than a grammatically perfect but confusing answer.
+- **One question at a time.** Wait for reply before next.
+- **Stay in the target language** for questions and transitions. Drop to native only for explanations.
+- **Praise natural expression.** If the learner uses "Nou..." or "Eh..." correctly, call it out — those are fluency markers.
+- **Don't over-correct.** A speaking session with 20 red marks kills confidence.
+- **Never auto-invoke.** Gated; must fire only on explicit `/speaking`.
+
+## Language Reference
+
+### Dutch A2 conversational fillers
+
+- "Nou..." (well / so)
+- "Eh..." (uh / um)
+- "Eigenlijk..." (actually)
+- "Dus..." (so / therefore)
+- "Ja, dat klopt" (yes, that's right)
+- "Ik snap het niet" (I don't understand)
+
+Add equivalents for other target languages as needed.

--- a/.agents/skills/vocab/SKILL.md
+++ b/.agents/skills/vocab/SKILL.md
@@ -1,0 +1,203 @@
+---
+name: vocab
+description: Run an interactive vocabulary drill session with flashcard-style prompts, spaced repetition, and per-answer feedback. Triggered only when the learner types /vocab. Reads spaced-repetition / mistakes / mastery DBs to pick words, presents one word at a time, scores each answer, and calls db-updater at the end.
+allowed-tools: Read, Write, Bash
+disable-model-invocation: true
+---
+
+# Vocabulary Drill Session
+
+## Overview
+
+Flashcard-style vocabulary practice using spaced repetition. One word at a time, immediate feedback, DB update at the end. Interleaves three modes (recognition, production, cloze) to force active recall rather than passive re-reading.
+
+## When to Use
+
+Trigger this skill only when the learner types `/vocab`. The skill is gated with `disable-model-invocation: true` — a false-positive auto-trigger would launch a 15-min interactive session and mutate 6 JSON databases. Not worth the risk.
+
+Skip this skill if no vocabulary items are due and no new words are queued — offer `/review` or `/learn` instead.
+
+## Instructions
+
+### 1. Load vocabulary data
+
+```bash
+python3 .claude/hooks/read-db.py
+```
+
+If the helper is unavailable, resolve `<data_dir>` via `fluent_paths.data_dir()` then read:
+
+- `<data_dir>/spaced-repetition.json`
+- `<data_dir>/mistakes-db.json`
+- `<data_dir>/mastery-db.json`
+- `<data_dir>/learner-profile.json` (for target_language, name, level)
+
+If any are missing, direct the learner to `/setup` and stop.
+
+### 2. Select words
+
+Priority order:
+
+1. Items in `spaced-repetition.review_queue.today` with `item_type == "vocabulary"`.
+2. Words from `mistakes-db.json` where `category == "vocabulary"` and `mastery_level <= 2`.
+3. New high-frequency words matching `learner-profile.focus_areas`.
+
+Limit: `spaced-repetition.daily_limits.review_items_per_day` (default 20).
+
+### 3. Present one word at a time
+
+Rotate the three modes so the session is not monotonous.
+
+**Recognition** (target_language → native):
+
+```markdown
+## Word {N}/{total}
+
+**{target_language}:** {word}
+
+**Context:** {example_sentence}
+
+**What does it mean in {native_language}?**
+
+**Type your answer:**
+```
+
+**Production** (native → target_language):
+
+```markdown
+## Word {N}/{total}
+
+**{native_language}:** {word}
+
+**Use it in a sentence (optional).**
+
+**How do you say this in {target_language}?**
+
+**Type your answer:**
+```
+
+**Cloze** (fill in the blank):
+
+```markdown
+## Word {N}/{total}
+
+**Complete the sentence:**
+
+{target_language sentence with _____ where the word goes}
+
+**Type the missing word:**
+```
+
+### 4. Feedback after each answer
+
+Use the `feedback-formatter` skill's template. Score out of 10, tag severity.
+
+Track the answer for the end-of-session DB update:
+
+- Add to `review_results[]` with `quality = floor(score / 2)` (see `sm2-calculator` skill).
+- If the learner met a new word, stage it for `new_vocabulary[]`.
+- If the learner made an error, stage it for `errors[]`.
+
+Do **not** call `update-db.py` after every word — batch at session end.
+
+### 5. Session summary
+
+```markdown
+## 📚 Vocabulary Session Complete!
+
+**Words Reviewed:** {N}
+**Accuracy:** {X}%
+**New Words Learned:** {Y}
+**Words Mastered (→ level 5):** {Z}
+
+**Strong:** {list words with mastery 4-5}
+**Need more practice:** {list words with mastery 0-2}
+
+**Next review:**
+- Tomorrow: {count} words
+- This week: {count} words
+
+{target-language "well done"}! 🌟
+```
+
+### 6. Update all databases
+
+Call the `db-updater` skill's workflow — one `update-db.py` invocation with:
+
+- `session_id`, `date`, `duration_minutes`
+- `command_used: "/vocab"`
+- `skills_practiced: ["vocabulary"]`
+- `skill_scores.vocabulary`: `{exercises, correct, time_minutes}`
+- `errors[]`, `new_vocabulary[]`, `review_results[]` collected during the session
+- `focus_next_session[]` — top 2-3 weak words
+
+## Examples
+
+### Example 1 — recognition drill
+
+> ## Word 1/15
+>
+> **Dutch:** de keuken
+>
+> **Context:** "De keuken is klein maar mooi."
+>
+> **What does it mean in English?**
+>
+> Type your answer:
+
+Learner: "the kitchen"
+
+> ✅ Exactly.
+>
+> **Answer:** the kitchen
+> **Meaning:** A room used for cooking and food preparation.
+> **Example:** "De keuken is klein maar mooi." (The kitchen is small but pretty.)
+>
+> **Score: 10/10** 🎯
+>
+> ---
+
+### Example 2 — production with error
+
+> ## Word 7/15
+>
+> **English:** to write
+>
+> **How do you say this in Dutch?**
+
+Learner: "schrijven"
+
+> ✅ Correct — infinitive form.
+>
+> Now: can you also give the first-person present? (I write → …)
+
+### Example 3 — session end summary
+
+> ## 📚 Vocabulary Session Complete!
+>
+> **Words Reviewed:** 15
+> **Accuracy:** 80% (12/15)
+> **New Words Learned:** 3
+> **Words Mastered:** 1
+>
+> **Need more practice:** de sleutel, het raam, gisteren
+>
+> **Next review:** Tomorrow 4 words, this week 8 words.
+>
+> Goed gedaan! 🌟
+
+## Critical Rules
+
+- **One word at a time.** Wait for the learner's answer before showing the next.
+- **Immediate feedback** after each — use `feedback-formatter`.
+- **Mix modes.** Don't drill 20 recognition prompts in a row — interleave for discrimination.
+- **Use target language** for greetings + transitions when the learner is B1+; for A1-A2 mix target + native.
+- **Never** update the DBs mid-session — batch at end.
+- **Never auto-invoke.** This skill is gated; must fire only on explicit `/vocab`.
+
+## Tips for the Learner (append if they seem tired or unsure)
+
+- Review daily for best retention — spaced repetition depends on it.
+- Focus time on weak words (mastery 0-2), not already-strong ones.
+- Use words in sentences to build contextual memory.
+- Say words out loud even though you're typing.

--- a/.agents/skills/wortchallenge/SKILL.md
+++ b/.agents/skills/wortchallenge/SKILL.md
@@ -1,0 +1,158 @@
+---
+name: wortchallenge
+description: Run an interactive German vocabulary challenge sourced only from the configured Obsidian words folder. Triggered only when the learner types /wortchallenge. Unknown or weakly answered words are added to Fluent as normal vocabulary items so /vocab can review them later.
+allowed-tools: Read, Write, Bash
+disable-model-invocation: true
+---
+
+# Wörter Challenge Session
+
+## Overview
+
+Challenge the learner on German vocabulary notes from the Obsidian `words/` folder. This is not a spaced-repetition review session by itself. It is a discovery gate: words scored below 7/10 are saved as Fluent vocabulary items so `/vocab` can ask them later.
+
+## When to Use
+
+Trigger only when the learner types `/wortchallenge`.
+
+## Instructions
+
+### 1. Load learner and words context
+
+Run from the Fluent repo root:
+
+```bash
+python3 .claude/hooks/read-db.py
+python3 .claude/hooks/wortchallenge_words.py
+```
+
+If `wortchallenge_words.py` fails because no source is configured, ask the learner to create `data/wortchallenge-source.json`:
+
+```json
+{
+  "words_dir": "/Users/necatifurkancolak/Desktop/wörter/words",
+  "daily_limit": 20
+}
+```
+
+The helper returns parsed notes from `words_dir`. It excludes `Hub` and `Big-Hub` notes and includes normal `Noun`, `Verb`, `Adjective`, `Phrase`, and `Expression` notes.
+
+### 2. Select words
+
+Use up to `daily_limit` words from the helper output. Default to 20 if no limit is configured.
+
+Each word object has:
+
+- `item_id`
+- `content`
+- `answer`
+- `note_type`
+- `turkish`
+- `english`
+- `common_patterns`
+- `example_sentences`
+- `first_example`
+- `source.note_path`
+- `source.obsidian_link`
+
+### 3. Present one word at a time
+
+Rotate prompt modes:
+
+**Production** (Turkish to German):
+
+```markdown
+## Wortchallenge {N}/{total}
+
+**Türkçe:** {main Turkish meaning}
+
+**Almanca nasıl söylenir?**
+
+Type your answer:
+```
+
+**Recognition** (German to Turkish):
+
+```markdown
+## Wortchallenge {N}/{total}
+
+**Deutsch:** {content}
+
+**Türkçe anlamı nedir?**
+
+Type your answer:
+```
+
+**Cloze** (example sentence):
+
+```markdown
+## Wortchallenge {N}/{total}
+
+**Complete the sentence:**
+
+{first_example with the target word replaced by _____}
+
+Type the missing word:
+```
+
+If no example sentence exists, use production mode.
+
+### 4. Feedback after each answer
+
+Use `feedback-formatter`. Score out of 10 and tag severity.
+
+Stage answer data in memory:
+
+- Scores `7-10`: mark as known for the summary only.
+- Scores `<7`: mark as unknown and stage for `new_vocabulary[]` and `errors[]`.
+
+Do not call `update-db.py` after each answer.
+
+### 5. Session end and DB update
+
+At the end, call `db-updater` with one payload:
+
+- `command_used: "/wortchallenge"`
+- `skills_practiced: ["vocabulary"]`
+- `skill_scores.vocabulary`: `{exercises, correct, time_minutes}` where correct means score `>=7`
+- `new_vocabulary[]`: only unknown words scored `<7`
+- `errors[]`: one matching vocabulary error for each unknown word
+- no `review_results[]`
+
+For each unknown word, send a complete `new_vocabulary` item:
+
+```json
+{
+  "item_id": "{item_id}",
+  "item_type": "vocabulary",
+  "content": "{content}",
+  "answer": "{answer}",
+  "category": "{category}",
+  "difficulty": "{learner current level or empty}",
+  "due_date": "{today}",
+  "initial_quality": 2,
+  "priority": "high",
+  "source": {
+    "type": "wortchallenge",
+    "note_path": "{source.note_path}",
+    "obsidian_link": "{source.obsidian_link}"
+  }
+}
+```
+
+Create a result file:
+
+```text
+results/wortchallenge-session-{NNN}.md
+```
+
+Include the Q&A table, scores, unknown words added to `/vocab`, known words, and note source paths.
+
+## Critical Rules
+
+- Source words only from the configured `words/` folder.
+- Never import all words automatically.
+- Only words scored `<7/10` become Fluent vocabulary items.
+- Do not mutate Obsidian notes.
+- One question at a time.
+- Batch DB updates at session end.

--- a/.agents/skills/writing/SKILL.md
+++ b/.agents/skills/writing/SKILL.md
@@ -1,0 +1,232 @@
+---
+name: writing
+description: Run an interactive writing practice session (emails, letters, forms, short texts) with systematic error analysis, category-tagged corrections, and detailed feedback. Triggered only when the learner types /writing. Selects a scenario matched to mastery, lets the learner compose, then analyzes grammar, register, vocabulary, structure, and spelling before updating all databases.
+allowed-tools: Read, Write, Bash
+disable-model-invocation: true
+---
+
+# Writing Practice Session
+
+## Overview
+
+Full-text writing practice with systematic correction. One scenario per session, detailed feedback broken down by severity and category, DB update at end. Mastery-driven scenario selection keeps the task at the right level — challenging, not frustrating.
+
+## When to Use
+
+Trigger this skill only when the learner types `/writing`. The skill is gated with `disable-model-invocation: true` — a 15-20 min interactive session with DB writes should never start from an ambiguous prompt.
+
+Skip this skill in favor of `/vocab` if the learner has not yet hit mastery 2 in basic vocabulary — writing needs a minimum word bank.
+
+## Instructions
+
+### 1. Load context
+
+```bash
+python3 .claude/hooks/read-db.py
+```
+
+Need: `learner-profile` (level, target language, focus areas), `mistakes-db` (weak writing patterns), `mastery-db` (writing sub-skills).
+
+### 2. Pick scenario type
+
+From `mastery-db.skills_mastery`:
+
+- Formal email (if `writing_formal_email` mastery < 4)
+- Informal email (if `writing_informal_email` < 4)
+- Form filling (if `writing_forms` < 4)
+- Newsletter / personal text (if overall writing < 3)
+- Mixed scenarios (if all ≥ 4)
+
+Scenarios must match the learner's CEFR level — A2 uses everyday situations, B1+ adds opinion / complaint / inquiry.
+
+### 3. Present the task
+
+```markdown
+## ✍️ Writing Exercise
+
+**Scenario:** {clear description in native language}
+
+**Task:** Write a {type} in {target_language}.
+
+**Requirements:**
+- Length: {X-Y} words
+- Include: {must-include elements}
+- Register: {formal / informal}
+- Level: {CEFR}
+
+{Optional: example structure for harder tasks}
+
+**Write your {text_type} below:**
+```
+
+### 4. Wait for the full text
+
+Don't correct mid-composition. Let the learner finish.
+
+### 5. Systematic error analysis
+
+Check every sentence for these categories:
+
+1. **Grammar** — word order, conjugation, clause structure, articles
+2. **Formal/informal** — register consistency
+3. **Vocabulary** — wrong word, English mixing, register-wrong synonyms
+4. **Missing elements** — greeting, closing, required fields
+5. **Spelling** — minor at A2, weightier at B2+
+6. **Structure** — organization, flow, paragraphing
+
+Tag each finding with a severity: 🔴 critical, 🟡 moderate, 🟢 minor.
+
+### 6. Detailed feedback
+
+Diverges slightly from the standard `feedback-formatter` template because writing answers are multi-sentence. Use this variant:
+
+```markdown
+## Feedback
+
+### ✅ What You Did Well
+- {strength 1}
+- {strength 2}
+
+### ❌ Areas to Improve
+
+**Critical:** 🔴
+- {issue}: "{wrong}" → **"{correct}"** — {why}
+
+**Moderate:** 🟡
+- {issue}: {explanation}
+
+**Minor:** 🟢
+- {spelling / punctuation}
+
+### 📝 Corrected Version
+
+```
+{fully corrected text}
+```
+
+**Score: {X}/10**
+
+**Breakdown:**
+- Grammar: {Y}/10
+- Vocabulary: {Z}/10
+- Structure: {W}/10
+- Communication: {V}/10
+
+---
+```
+
+### 7. Optional rewrite
+
+If score < 7, offer:
+
+```markdown
+**Want to try again?** Rewriting with the corrections locks in the patterns.
+
+Type "rewrite" to try again, or "next" to continue.
+```
+
+### 8. Session summary
+
+```markdown
+## 📊 Writing Session Summary
+
+**Text Type:** {type}
+**Score:** {X}/10
+**Key Takeaways:**
+- {learning 1}
+- {learning 2}
+- {learning 3}
+
+**Next Time:**
+- Focus on: {weak pattern}
+- Review: {relevant flashcards}
+
+{target-language "well done"}! ✍️
+```
+
+### 9. Update all databases
+
+Use the `db-updater` skill:
+
+- `command_used: "/writing"`, `skills_practiced: ["writing"]`
+- `skill_scores.writing: {exercises: 1, correct: 1_if_score_≥_7_else_0, time_minutes}`
+- `errors[]` — one per distinct pattern found (dedupe; the script bumps frequency)
+- `focus_next_session[]` — top 2 patterns to drill
+
+Also save the exchange as `/results/writing-session-{NNN}.md` with the full task, the learner's original text, the corrected version, and the error table. The `session-analyzer` skill depends on this format.
+
+## Examples
+
+### Example 1 — formal email task (Dutch A2)
+
+> ## ✍️ Writing Exercise
+>
+> **Scenario:** You need to cancel a doctor's appointment you have on Thursday.
+>
+> **Task:** Write a formal email to the doctor's office in Dutch.
+>
+> **Requirements:**
+> - Length: 40-60 words
+> - Include: greeting, reason, request for new appointment, closing
+> - Register: formal
+> - Level: A2
+>
+> **Write your email below:**
+
+Learner: "Hallo, Ik schrijf je omdat ik kan niet komen op donderdag. Ik ben ziek. Kunnen we een andere dag afspreken? Bedankt, Mohammad"
+
+> ## Feedback
+>
+> ### ✅ What You Did Well
+> - Clear reason for cancellation.
+> - Correct request structure.
+>
+> ### ❌ Areas to Improve
+>
+> **Critical:** 🔴
+> - `formal_informal`: "Hallo" + "je" — formal email needs "Beste meneer/mevrouw" + "u". Mixed registers cost exam points.
+> - `grammar`: "ik kan niet komen" is OK standalone, but after "omdat" Dutch word order flips: **"omdat ik niet kan komen"**.
+>
+> **Moderate:** 🟡
+> - `missing`: no formal closing. Use "Met vriendelijke groet,".
+>
+> **Minor:** 🟢
+> - Capitalize "Donderdag"? Actually no — Dutch doesn't capitalize weekdays. You were right.
+>
+> ### 📝 Corrected Version
+>
+> ```
+> Beste meneer/mevrouw,
+>
+> Ik schrijf u omdat ik niet kan komen op donderdag. Ik ben ziek.
+> Kunnen we een andere dag afspreken?
+>
+> Met vriendelijke groet,
+> Mohammad
+> ```
+>
+> **Score: 6/10**
+> - Grammar: 6/10 — omdat word order tripped you up.
+> - Vocabulary: 8/10 — solid word choice.
+> - Structure: 5/10 — missing proper opening + closing.
+> - Communication: 7/10 — message was clear despite issues.
+
+## Critical Rules
+
+- **One scenario per session.** Don't chain multiple writing tasks — depth over breadth.
+- **Wait for the full answer** before correcting.
+- **Severity tagging is mandatory.** Fed into `mistakes-db` and drives spaced repetition priority.
+- **Always save the session file** in `/results/` for later analysis by `session-analyzer`.
+- **Never auto-invoke.** This skill is gated; must fire only on explicit `/writing`.
+
+## Language Reference
+
+### Dutch A2 patterns
+
+**Formal emails:** always "u" (not "je"); open `Beste meneer/mevrouw {NAME},`; closing `Met vriendelijke groet,` + name.
+
+**Informal emails:** "je" not "u"; open `Hallo {NAME},`; closing `Groetjes,` or `Tot snel,`.
+
+**Common mistakes:** mixing formal/informal in one text; word order in `omdat` clauses (verb last); time expressions (`om 10:00 uur`, `op dinsdag`).
+
+Add similar sections for other target languages as the learner needs them.

--- a/.claude/hooks/update-db.py
+++ b/.claude/hooks/update-db.py
@@ -360,7 +360,7 @@ def update_spaced_repetition(sr: dict, session: dict):
                 "category": vocab.get("category", ""),
                 "difficulty": vocab.get("difficulty", ""),
                 "created_date": today,
-                "due_date": tomorrow(today),
+                "due_date": vocab.get("due_date", tomorrow(today)),
                 "interval_days": 1,
                 "repetitions": 0,
                 "easiness_factor": 2.5,
@@ -372,6 +372,8 @@ def update_spaced_repetition(sr: dict, session: dict):
                 "total_reviews": 0,
                 "priority": vocab.get("priority", "medium"),
             }
+            if vocab.get("source"):
+                items[item_id]["source"] = vocab["source"]
 
     for error in session.get("errors", []):
         item_id = error["pattern_id"]

--- a/.claude/hooks/wortchallenge_words.py
+++ b/.claude/hooks/wortchallenge_words.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python3
+"""
+Read Wörterpraxis-style Obsidian word notes for /wortchallenge.
+
+This helper is read-only. It never imports words into Fluent by itself; the
+skill decides which unknown words to send to update-db.py as new_vocabulary.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+import unicodedata
+from pathlib import Path
+from typing import Dict, List, Optional
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from fluent_paths import data_dir  # noqa: E402
+
+CONFIG_PATH = data_dir() / "wortchallenge-source.json"
+ELIGIBLE_TYPES = {"noun", "verb", "adjective", "phrase", "expression"}
+EXCLUDED_TYPES = {"hub", "big-hub", "big hub"}
+
+
+def load_json(path: Path) -> dict:
+    with open(path, "r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def load_config() -> dict:
+    if CONFIG_PATH.exists():
+        return load_json(CONFIG_PATH)
+    return {}
+
+
+def resolve_words_dir(config: dict, words_dir: Optional[str] = None) -> Path:
+    value = (
+        words_dir
+        or os.environ.get("WORTCHALLENGE_WORDS_DIR")
+        or config.get("words_dir")
+    )
+    if not value:
+        raise ValueError(
+            "No words_dir configured. Create data/wortchallenge-source.json "
+            "or set WORTCHALLENGE_WORDS_DIR."
+        )
+    resolved = Path(value).expanduser().resolve()
+    if not resolved.is_dir():
+        raise FileNotFoundError(f"words_dir not found: {resolved}")
+    return resolved
+
+
+def section(markdown: str, heading: str) -> str:
+    pattern = rf"(?ims)^##\s+{re.escape(heading)}\s*$\n(.*?)(?=^##\s+|\Z)"
+    match = re.search(pattern, markdown)
+    return match.group(1).strip() if match else ""
+
+
+def subsection(markdown: str, heading: str) -> str:
+    pattern = rf"(?ims)^###\s+{re.escape(heading)}\s*$\n(.*?)(?=^###\s+|^##\s+|\Z)"
+    match = re.search(pattern, markdown)
+    return match.group(1).strip() if match else ""
+
+
+def first_nonempty_line(text: str) -> str:
+    for line in text.splitlines():
+        cleaned = line.strip()
+        if cleaned and not cleaned.startswith("|---"):
+            return cleaned.strip("- ").strip()
+    return ""
+
+
+def title_from_note(path: Path, markdown: str) -> str:
+    match = re.search(r"(?m)^#\s+(.+?)\s*$", markdown)
+    return match.group(1).strip() if match else path.stem
+
+
+def normalize_id(text: str) -> str:
+    text = text.strip()
+    text = re.sub(r"^(der|die|das)\s+", "", text, flags=re.IGNORECASE)
+    replacements = str.maketrans({
+        "ä": "ae", "ö": "oe", "ü": "ue", "ß": "ss",
+        "Ä": "ae", "Ö": "oe", "Ü": "ue",
+    })
+    text = text.translate(replacements)
+    text = unicodedata.normalize("NFKD", text)
+    text = "".join(ch for ch in text if not unicodedata.combining(ch))
+    text = re.sub(r"[^A-Za-z0-9]+", "_", text.lower()).strip("_")
+    return text or "item"
+
+
+def first_example(examples: str) -> str:
+    for line in examples.splitlines():
+        cleaned = line.strip()
+        match = re.match(r"^\d+\.\s+(.+)$", cleaned)
+        if match:
+            return match.group(1).strip()
+    return ""
+
+
+def parse_note(path: Path) -> Optional[Dict[str, object]]:
+    markdown = path.read_text(encoding="utf-8")
+    title = title_from_note(path, markdown)
+    note_type = first_nonempty_line(section(markdown, "Type"))
+    note_type_key = note_type.lower().strip()
+
+    if note_type_key in EXCLUDED_TYPES or note_type_key not in ELIGIBLE_TYPES:
+        return None
+
+    turkish = subsection(markdown, "Turkish")
+    english = subsection(markdown, "English")
+    if not title or not first_nonempty_line(turkish):
+        return None
+
+    patterns = section(markdown, "Common Patterns")
+    examples = section(markdown, "Example Sentences")
+
+    answer_parts = [first_nonempty_line(turkish)]
+    english_line = first_nonempty_line(english)
+    if english_line:
+        answer_parts.append(english_line)
+
+    item_id = f"wortchallenge_{normalize_id(title)}"
+    return {
+        "item_id": item_id,
+        "item_type": "vocabulary",
+        "content": title,
+        "answer": " / ".join(answer_parts),
+        "category": f"wortchallenge_{normalize_id(note_type or 'vocabulary')}",
+        "difficulty": "",
+        "priority": "medium",
+        "source": {
+            "type": "wortchallenge",
+            "note_path": str(path),
+            "obsidian_link": f"[[{title}]]",
+        },
+        "note_type": note_type,
+        "turkish": turkish,
+        "english": english,
+        "common_patterns": patterns,
+        "example_sentences": examples,
+        "first_example": first_example(examples),
+    }
+
+
+def load_words(words_dir: Path, limit: Optional[int] = None) -> Dict[str, object]:
+    words: List[Dict[str, object]] = []
+    skipped: List[str] = []
+    for path in sorted(words_dir.glob("*.md")):
+        parsed = parse_note(path)
+        if parsed is None:
+            skipped.append(str(path))
+            continue
+        words.append(parsed)
+        if limit is not None and len(words) >= limit:
+            break
+    return {
+        "words_dir": str(words_dir),
+        "words": words,
+        "skipped": skipped,
+        "count": len(words),
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--words-dir")
+    parser.add_argument("--limit", type=int)
+    args = parser.parse_args()
+
+    try:
+        config = load_config()
+        words_dir = resolve_words_dir(config, args.words_dir)
+        result = load_words(words_dir, args.limit or config.get("daily_limit"))
+    except Exception as exc:
+        print(f"[Fluent] wortchallenge word loading failed: {exc}", file=sys.stderr)
+        return 1
+
+    print(json.dumps(result, ensure_ascii=False, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.claude/skills/wortchallenge/SKILL.md
+++ b/.claude/skills/wortchallenge/SKILL.md
@@ -1,0 +1,158 @@
+---
+name: wortchallenge
+description: Run an interactive German vocabulary challenge sourced only from the configured Obsidian words folder. Triggered only when the learner types /wortchallenge. Unknown or weakly answered words are added to Fluent as normal vocabulary items so /vocab can review them later.
+allowed-tools: Read, Write, Bash
+disable-model-invocation: true
+---
+
+# Wörter Challenge Session
+
+## Overview
+
+Challenge the learner on German vocabulary notes from the Obsidian `words/` folder. This is not a spaced-repetition review session by itself. It is a discovery gate: words scored below 7/10 are saved as Fluent vocabulary items so `/vocab` can ask them later.
+
+## When to Use
+
+Trigger only when the learner types `/wortchallenge`.
+
+## Instructions
+
+### 1. Load learner and words context
+
+Run from the Fluent repo root:
+
+```bash
+python3 .claude/hooks/read-db.py
+python3 .claude/hooks/wortchallenge_words.py
+```
+
+If `wortchallenge_words.py` fails because no source is configured, ask the learner to create `data/wortchallenge-source.json`:
+
+```json
+{
+  "words_dir": "/Users/necatifurkancolak/Desktop/wörter/words",
+  "daily_limit": 20
+}
+```
+
+The helper returns parsed notes from `words_dir`. It excludes `Hub` and `Big-Hub` notes and includes normal `Noun`, `Verb`, `Adjective`, `Phrase`, and `Expression` notes.
+
+### 2. Select words
+
+Use up to `daily_limit` words from the helper output. Default to 20 if no limit is configured.
+
+Each word object has:
+
+- `item_id`
+- `content`
+- `answer`
+- `note_type`
+- `turkish`
+- `english`
+- `common_patterns`
+- `example_sentences`
+- `first_example`
+- `source.note_path`
+- `source.obsidian_link`
+
+### 3. Present one word at a time
+
+Rotate prompt modes:
+
+**Production** (Turkish to German):
+
+```markdown
+## Wortchallenge {N}/{total}
+
+**Türkçe:** {main Turkish meaning}
+
+**Almanca nasıl söylenir?**
+
+Type your answer:
+```
+
+**Recognition** (German to Turkish):
+
+```markdown
+## Wortchallenge {N}/{total}
+
+**Deutsch:** {content}
+
+**Türkçe anlamı nedir?**
+
+Type your answer:
+```
+
+**Cloze** (example sentence):
+
+```markdown
+## Wortchallenge {N}/{total}
+
+**Complete the sentence:**
+
+{first_example with the target word replaced by _____}
+
+Type the missing word:
+```
+
+If no example sentence exists, use production mode.
+
+### 4. Feedback after each answer
+
+Use `feedback-formatter`. Score out of 10 and tag severity.
+
+Stage answer data in memory:
+
+- Scores `7-10`: mark as known for the summary only.
+- Scores `<7`: mark as unknown and stage for `new_vocabulary[]` and `errors[]`.
+
+Do not call `update-db.py` after each answer.
+
+### 5. Session end and DB update
+
+At the end, call `db-updater` with one payload:
+
+- `command_used: "/wortchallenge"`
+- `skills_practiced: ["vocabulary"]`
+- `skill_scores.vocabulary`: `{exercises, correct, time_minutes}` where correct means score `>=7`
+- `new_vocabulary[]`: only unknown words scored `<7`
+- `errors[]`: one matching vocabulary error for each unknown word
+- no `review_results[]`
+
+For each unknown word, send a complete `new_vocabulary` item:
+
+```json
+{
+  "item_id": "{item_id}",
+  "item_type": "vocabulary",
+  "content": "{content}",
+  "answer": "{answer}",
+  "category": "{category}",
+  "difficulty": "{learner current level or empty}",
+  "due_date": "{today}",
+  "initial_quality": 2,
+  "priority": "high",
+  "source": {
+    "type": "wortchallenge",
+    "note_path": "{source.note_path}",
+    "obsidian_link": "{source.obsidian_link}"
+  }
+}
+```
+
+Create a result file:
+
+```text
+results/wortchallenge-session-{NNN}.md
+```
+
+Include the Q&A table, scores, unknown words added to `/vocab`, known words, and note source paths.
+
+## Critical Rules
+
+- Source words only from the configured `words/` folder.
+- Never import all words automatically.
+- Only words scored `<7/10` become Fluent vocabulary items.
+- Do not mutate Obsidian notes.
+- One question at a time.
+- Batch DB updates at session end.

--- a/.gitignore
+++ b/.gitignore
@@ -2,9 +2,13 @@
 /data/*.json
 /data/*.json.backup-*
 /results/*.md
+/words/
 # Except the README files which explain the structure
 !/data/README.md
 !/results/README.md
+
+# Git worktrees created by Claude Code sessions
+/.claude/worktrees/
 
 # Personal writing/practice files
 myfile.txt

--- a/tests/test_update_db.py
+++ b/tests/test_update_db.py
@@ -236,6 +236,55 @@ class UpdateDbSmokeTest(unittest.TestCase):
             profile = json.load(f)
         self.assertEqual(profile["current_streak_days"], 2)
 
+    def test_wortchallenge_new_vocab_preserves_source_metadata(self):
+        payload = {
+            "session_id": "session-004",
+            "date": "2026-04-24",
+            "duration_minutes": 8,
+            "command_used": "/wortchallenge",
+            "skills_practiced": ["vocabulary"],
+            "skill_scores": {
+                "vocabulary": {"exercises": 1, "correct": 0, "time_minutes": 8}
+            },
+            "new_vocabulary": [{
+                "item_id": "wortchallenge_antrieb",
+                "item_type": "vocabulary",
+                "content": "Antrieb",
+                "answer": "itici güç / motivasyon / drive / motivation",
+                "category": "wortchallenge_noun",
+                "difficulty": "B1",
+                "due_date": "2026-04-24",
+                "initial_quality": 2,
+                "priority": "high",
+                "source": {
+                    "type": "wortchallenge",
+                    "note_path": "/tmp/vault/words/Antrieb.md",
+                    "obsidian_link": "[[Antrieb]]",
+                },
+            }],
+            "errors": [{
+                "pattern_id": "wortchallenge_antrieb",
+                "category": "vocabulary",
+                "your_answer": "idk",
+                "correct_answer": "Antrieb",
+                "context": "wortchallenge unknown word",
+                "severity": "critical",
+            }],
+        }
+
+        proc = self._run(payload)
+        self.assertEqual(proc.returncode, 0, msg=proc.stderr)
+
+        with open(self.tmp / "data" / "spaced-repetition.json") as f:
+            sr = json.load(f)
+
+        item = sr["items"]["wortchallenge_antrieb"]
+        self.assertEqual(item["type"], "vocabulary")
+        self.assertEqual(item["priority"], "high")
+        self.assertEqual(item["source"]["type"], "wortchallenge")
+        self.assertEqual(item["source"]["obsidian_link"], "[[Antrieb]]")
+        self.assertIn("wortchallenge_antrieb", sr["review_queue"]["today"])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_wortchallenge_words.py
+++ b/tests/test_wortchallenge_words.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+"""Tests for .claude/hooks/wortchallenge_words.py."""
+import importlib.util
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCRIPT = REPO_ROOT / ".claude" / "hooks" / "wortchallenge_words.py"
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location("wortchallenge_words", SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+NOTE_TEMPLATE = """# {title}
+
+## Type
+{note_type}
+
+## Meaning
+### Turkish
+{turkish}
+
+### English
+{english}
+
+### Simple German Explanation
+Eine kurze Erklärung.
+
+## Grammar
+-
+
+## Forms
+-
+
+## Common Patterns
+| German Pattern | Turkish | English |
+|---|---|---|
+| {title} benutzen | kullanmak | to use |
+
+## Example Sentences
+1. Ich benutze {title} heute.
+2. Das ist ein Beispiel.
+3. Wir lernen zusammen.
+4. Der Satz ist kurz.
+
+## Related Nodes
+
+## Family Root
+"""
+
+
+class WortchallengeWordsTest(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.words_dir = Path(self.tmp.name)
+        (self.words_dir / "Antrieb.md").write_text(
+            NOTE_TEMPLATE.format(
+                title="Antrieb",
+                note_type="Noun",
+                turkish="itici güç / motivasyon",
+                english="drive / motivation",
+            ),
+            encoding="utf-8",
+        )
+        (self.words_dir / "ablehnen.md").write_text(
+            NOTE_TEMPLATE.format(
+                title="ablehnen",
+                note_type="Verb",
+                turkish="reddetmek",
+                english="to reject",
+            ),
+            encoding="utf-8",
+        )
+        (self.words_dir / "Bau.md").write_text(
+            NOTE_TEMPLATE.format(
+                title="Bau",
+                note_type="Hub",
+                turkish="yapı / inşa",
+                english="construction",
+            ),
+            encoding="utf-8",
+        )
+        (self.words_dir / "Malformed.md").write_text(
+            "# Malformed\n\n## Type\nNoun\n\n## Meaning\n### English\nbroken",
+            encoding="utf-8",
+        )
+        self.module = load_module()
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def test_load_words_includes_normal_notes_only(self):
+        result = self.module.load_words(self.words_dir)
+        contents = [word["content"] for word in result["words"]]
+
+        self.assertEqual(contents, ["Antrieb", "ablehnen"])
+        self.assertEqual(result["count"], 2)
+        self.assertTrue(any("Bau.md" in path for path in result["skipped"]))
+        self.assertTrue(any("Malformed.md" in path for path in result["skipped"]))
+
+    def test_parse_note_builds_vocab_payload_fields(self):
+        parsed = self.module.parse_note(self.words_dir / "Antrieb.md")
+
+        self.assertEqual(parsed["item_id"], "wortchallenge_antrieb")
+        self.assertEqual(parsed["item_type"], "vocabulary")
+        self.assertIn("itici güç", parsed["answer"])
+        self.assertEqual(parsed["source"]["type"], "wortchallenge")
+        self.assertEqual(parsed["source"]["obsidian_link"], "[[Antrieb]]")
+        self.assertIn("Ich benutze", parsed["first_example"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Three commits adding a `/wortchallenge` skill that drills German vocabulary from a worterpraxis-style Obsidian vault and pushes weakly-answered words (score < 7/10) into Fluent's spaced-repetition queue.

- **feat:** new `/wortchallenge` skill with a read-only `wortchallenge_words.py` helper that parses note Markdown (Hub/Big-Hub filtered, source metadata preserved). `update-db.py` now respects custom `due_date` and a `source` field on `new_vocabulary[]` entries so notes round-trip with their `obsidian_link`.
- **chore:** gitignore `/words` (user vault, same class as `/data/*.json`) and `/.claude/worktrees/` (Claude Code session metadata).
- **chore:** add Codex skill mirrors under `.agents/skills/` for the existing 12 Fluent skills. Path bugs in the auto-generated mirrors were fixed: `.Codex/hooks/` → `.claude/hooks/`, `.Codex/references/` → `.claude/references/`, `~/.Codex/fluent-data/` → `~/.codex/fluent-data/` (OpenAI Codex CLI uses lowercase).

Configuration is via `data/wortchallenge-source.json` (gitignored) or the `WORTCHALLENGE_WORDS_DIR` env var — no hardcoded paths.

## Test plan

- [x] `python3 -m unittest tests.test_wortchallenge_words tests.test_update_db` — 6/6 PASS
- [ ] `/wortchallenge` end-to-end in a real Claude Code session against the vault
- [ ] Verify weak-word entries land in `spaced-repetition.json` with `source.obsidian_link` and surface in next `/review`