### PR TITLE
feat(multi-lang): add multi-language support with /fluent-lang skill

### DIFF
--- a/.claude/hooks/fluent_paths.py
+++ b/.claude/hooks/fluent_paths.py
@@ -3,16 +3,22 @@ Fluent path resolution — supports dual-mode (clone vs plugin install).
 
 Data directory resolution precedence:
   1. $FLUENT_DATA_DIR if set (absolutized)
-  2. $CLAUDE_PROJECT_DIR/data if that dir holds learner-profile.json (clone mode, non-repo cwd)
-  3. ./data if ./data/learner-profile.json exists (clone mode, in-repo cwd)
-  4. ~/.claude/fluent-data (plugin-mode fallback)
+  2. $CLAUDE_PROJECT_DIR/data/$FLUENT_LANG (clone mode, if FLUENT_LANG is set)
+  3. $CLAUDE_PROJECT_DIR/data if that dir holds learner-profile.json (clone mode, no FLUENT_LANG)
+  4. ./data/$FLUENT_LANG (clone mode, in-repo cwd, if FLUENT_LANG is set)
+  5. ./data if ./data/learner-profile.json exists (clone mode, in-repo cwd)
+  6. ~/.claude/fluent-data/$FLUENT_LANG (plugin-mode fallback, if FLUENT_LANG is set)
+  7. ~/.claude/fluent-data (plugin-mode fallback)
+
+Set FLUENT_LANG=es (or fr, de, …) to study a specific language in isolation.
+Each language gets its own data subdirectory and results subdirectory.
 
 Plugin-root resolution precedence:
   1. $CLAUDE_PLUGIN_ROOT if set
   2. $CLAUDE_PROJECT_DIR if set
   3. parent of this file's .claude/ dir (dev-run fallback)
 
-Pure resolvers (data_dir / plugin_root / backups_dir) do not create directories.
+Pure resolvers (data_dir / plugin_root / backups_dir / results_dir) do not create directories.
 Call ensure_data_dir() before writing.
 """
 from __future__ import annotations
@@ -38,23 +44,68 @@ def force_utf8_io() -> None:
             pass
 
 
+def active_lang_file() -> Path:
+    """Path to the persisted active-language config file (~/.claude/fluent-active-lang).
+
+    Written by /fluent-lang skill. FLUENT_LANG env var takes precedence over this file.
+    """
+    return Path.home() / ".claude" / "fluent-active-lang"
+
+
+def _active_lang() -> str:
+    """Return the active language code (lowercase) or empty string.
+
+    Priority: FLUENT_LANG env var > ~/.claude/fluent-active-lang file.
+    """
+    env = os.environ.get("FLUENT_LANG", "").strip().lower()
+    if env:
+        return env
+    cfg = active_lang_file()
+    if cfg.exists():
+        try:
+            return cfg.read_text(encoding="utf-8").strip().lower()
+        except OSError:
+            pass
+    return ""
+
+
 @lru_cache(maxsize=1)
 def data_dir() -> Path:
-    """Resolve the runtime data directory (pure — does not create it)."""
+    """Resolve the runtime data directory (pure — does not create it).
+
+    When FLUENT_LANG is set the resolved directory is always the language
+    subdirectory (e.g. data/es/) regardless of whether it exists yet —
+    ensure_data_dir() creates it on first use.
+    """
     env = os.environ.get("FLUENT_DATA_DIR")
     if env:
         return Path(env).expanduser().resolve()
 
+    lang = _active_lang()
+
     project = os.environ.get("CLAUDE_PROJECT_DIR")
     if project:
-        candidate = (Path(project) / "data").resolve()
-        if (candidate / "learner-profile.json").exists():
-            return candidate
+        base = (Path(project) / "data").resolve()
+        if lang:
+            candidate = base / lang
+            # Use project-based lang dir only when in clone mode:
+            # language subdir already has a profile, OR root data dir has one
+            # (profile at root = clone mode that hasn't yet been partitioned).
+            if (candidate / "learner-profile.json").exists() or (base / "learner-profile.json").exists():
+                return candidate
+        elif (base / "learner-profile.json").exists():
+            return base
 
     cwd_data = (Path.cwd() / "data").resolve()
-    if (cwd_data / "learner-profile.json").exists():
+    if lang:
+        candidate = cwd_data / lang
+        if (candidate / "learner-profile.json").exists() or (cwd_data / "learner-profile.json").exists():
+            return candidate
+    elif (cwd_data / "learner-profile.json").exists():
         return cwd_data
 
+    if lang:
+        return (Path.home() / ".claude" / "fluent-data" / lang).resolve()
     return (Path.home() / ".claude" / "fluent-data").resolve()
 
 
@@ -90,3 +141,25 @@ def ensure_backups_dir() -> Path:
     b = backups_dir()
     b.mkdir(parents=True, exist_ok=True)
     return b
+
+
+@lru_cache(maxsize=1)
+def results_dir() -> Path:
+    """Resolve the results directory.
+
+    When FLUENT_LANG is set returns results/{lang}/ so each language keeps
+    its own session history (e.g. results/es/, results/fr/).
+    Falls back to results/ for single-language setups.
+    """
+    lang = _active_lang()
+    root = plugin_root()
+    if lang:
+        return root / "results" / lang
+    return root / "results"
+
+
+def ensure_results_dir() -> Path:
+    """Resolve the results directory and create it if missing."""
+    r = results_dir()
+    r.mkdir(parents=True, exist_ok=True)
+    return r

--- a/.claude/hooks/read-db.py
+++ b/.claude/hooks/read-db.py
@@ -15,7 +15,7 @@ from datetime import datetime, timedelta
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
-from fluent_paths import data_dir, force_utf8_io  # noqa: E402
+from fluent_paths import data_dir, force_utf8_io, results_dir  # noqa: E402
 
 force_utf8_io()
 DATA_DIR = data_dir()
@@ -89,6 +89,7 @@ def main():
             "next_session_id": next_session_id(sessions),
             "streak_active": streak_active,
             "days_since_last_session": days_since,
+            "results_dir": str(results_dir()),
         },
     }
 

--- a/.claude/skills/fluent-lang/SKILL.md
+++ b/.claude/skills/fluent-lang/SKILL.md
@@ -1,0 +1,118 @@
+---
+name: fluent-lang
+description: Switch the active study language mid-session by writing a language code to ~/.claude/fluent-active-lang. Invoke when the learner types /fluent-lang, /fluent-lang <code> (e.g. /fluent-lang fr, /fluent-lang es), or says anything like "switch to French", "quiero estudiar español", "change language", "study French now", "cambiar idioma". Shows current language if no code given. Takes effect immediately — no restart required. Never auto-invoke from general conversation.
+allowed-tools: Read, Write, Bash
+disable-model-invocation: true
+---
+
+# Language Switcher
+
+## Overview
+
+Fluent keeps all learner data in a language-specific directory (e.g. `~/.claude/fluent-data/es/` for Spanish, `~/.claude/fluent-data/fr/` for French). The active language is stored in a single line in `~/.claude/fluent-active-lang`. This skill writes that file, which takes effect immediately — every subsequent `read-db.py` call, exercise, and database update in this session will use the new language's data.
+
+## When to Use
+
+Trigger only when the learner explicitly switches languages — `/fluent-lang fr`, "switch to French", "quiero estudiar español now", or similar. Do not auto-invoke from general practice prompts.
+
+## Instructions
+
+### 1. Determine the requested language
+
+The learner either typed `/fluent-lang <code>` or said something like "switch to French".
+
+Map natural language to a code:
+
+| Phrase | Code |
+|--------|------|
+| Spanish / español | `es` |
+| French / français / francés | `fr` |
+| German / deutsch / alemán | `de` |
+| Portuguese / português | `pt` |
+| Italian / italiano | `it` |
+| Japanese / 日本語 / japonés | `ja` |
+| Chinese / 中文 / chino | `zh` |
+| Korean / 한국어 / coreano | `ko` |
+| Dutch / nederlands / holandés | `nl` |
+| Arabic / عربي / árabe | `ar` |
+
+If no language was given (bare `/fluent-lang`), jump to **Show current language** below.
+
+If the learner named a language not in this list, use the standard two-letter ISO 639-1 code (lowercase). Unknown codes are fine — the user can run `/fluent-setup` to create a profile for any language.
+
+### 2. Write the config file
+
+Write **only the language code** (lowercase, single line) to `~/.claude/fluent-active-lang` using the Write tool:
+
+```
+~/.claude/fluent-active-lang
+---
+<code>
+```
+
+For example, switching to French writes exactly:
+```
+fr
+```
+
+Nothing else — no quotes, no newlines, no JSON.
+
+### 3. Verify and load the new context
+
+Run `read-db.py` to confirm the switch worked and load the new language's profile:
+
+```bash
+python3 "${CLAUDE_PLUGIN_ROOT:-${CLAUDE_PROJECT_DIR:-.}}/.claude/hooks/read-db.py"
+```
+
+Check `computed.results_dir` in the output — it should now point to the new language's subdirectory (e.g. `.../results/fr/`).
+
+### 4. Respond based on profile state
+
+**Profile found** (`databases.learner_profile` is populated):
+
+Welcome the learner back with a brief status snapshot:
+
+```
+🇫🇷 Switched to French!
+
+Welcome back, {name}. Here's where you left off:
+- Level: {current_level} → {target_level}
+- Streak: {current_streak_days} days 🔥
+- Due reviews: {due_reviews_count} items
+
+{if due_reviews_count > 0: "Start with /fluent-review to clear your queue."}
+{else: "Ready to practice? Try /fluent-learn or /fluent-vocab."}
+```
+
+Use the flag emoji matching the language (see table in step 1).
+
+**No profile found** (`databases.learner_profile` is empty or missing):
+
+```
+🇫🇷 Switched to French!
+
+No French profile found yet. Run /fluent-setup to create your French learner profile — it only takes a minute.
+```
+
+---
+
+### Show current language (no argument given)
+
+Read `~/.claude/fluent-active-lang` to get the current code.
+
+If the file does not exist or is empty, fall back to the `target_language` field from `read-db.py`'s learner profile output.
+
+Reply with something like:
+
+```
+Currently studying: Spanish 🇪🇸 (es)
+
+To switch, type /fluent-lang <code> — e.g. /fluent-lang fr for French.
+```
+
+## Critical Rules
+
+- Write **only** the language code to `~/.claude/fluent-active-lang` — no other files touched.
+- The session-start greeting at the top of the session still shows the old language; that is expected. The switch affects all operations from this point forward.
+- Never reset or modify any learner database files — this skill only writes the config file.

--- a/.claude/skills/fluent-learn/SKILL.md
+++ b/.claude/skills/fluent-learn/SKILL.md
@@ -147,7 +147,7 @@ Then use the `fluent-db-updater` skill:
 - `errors[]`, `new_vocabulary[]`, `review_results[]`
 - `breakthroughs[]`, `focus_next_session[]`, `session_notes`
 
-Save exchange to `/results/fluent-learn-session-{NNN}.md`.
+Save exchange to `{computed.results_dir}/fluent-learn-session-{NNN}.md` (use the `results_dir` value from the `read-db.py` output — e.g. `results/es/` when `FLUENT_LANG=es`).
 
 ## Examples
 

--- a/.claude/skills/fluent-reading/SKILL.md
+++ b/.claude/skills/fluent-reading/SKILL.md
@@ -202,7 +202,7 @@ Use the `fluent-db-updater` skill:
 - `new_vocabulary[]` — words the learner chose to save
 - `focus_next_session[]`
 
-Save to `/results/fluent-reading-session-{NNN}.md` — include the full text + Q&A for later analysis.
+Save to `{computed.results_dir}/fluent-reading-session-{NNN}.md` — include the full text + Q&A for later analysis. Use the `results_dir` value from the `read-db.py` output.
 
 ## Examples
 

--- a/.claude/skills/fluent-review/SKILL.md
+++ b/.claude/skills/fluent-review/SKILL.md
@@ -152,7 +152,7 @@ Use the `fluent-db-updater` skill:
 - `errors[]` — only patterns where the learner got it wrong (bumps frequency)
 - `focus_next_session[]` — the 2-3 items with lowest quality this session
 
-Save exchange to `/results/fluent-review-session-{NNN}.md` for later analysis.
+Save exchange to `{computed.results_dir}/fluent-review-session-{NNN}.md` for later analysis. Use the `results_dir` value from the `read-db.py` output.
 
 ## Examples
 

--- a/.claude/skills/fluent-session-analyzer/SKILL.md
+++ b/.claude/skills/fluent-session-analyzer/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: fluent-session-analyzer
-description: Parse Fluent `/results/*.md` session files to extract error patterns, strengths, accuracy trends, and focus areas for the next session. Use when the tutor needs to analyze the learner's recent performance — planning the next lesson, recommending focus areas, or answering "what should I practice next?".
+description: Parse Fluent session files (in `computed.results_dir` from read-db.py) to extract error patterns, strengths, accuracy trends, and focus areas for the next session. Use when the tutor needs to analyze the learner's recent performance — planning the next lesson, recommending focus areas, or answering "what should I practice next?".
 ---
 
 # Session Analyzer
 
 ## Overview
 
-Every practice session writes a markdown report to `/results/{skill}-session-{ID}.md` (e.g. `writing-session-012.md`). This skill describes how to read those files to plan adaptive follow-up practice. Use it when the tutor needs narrative context the JSON databases don't capture — the exact sentence the learner wrote, the scenario, the feedback they received.
+Every practice session writes a markdown report to `{computed.results_dir}/{skill}-session-{ID}.md` (e.g. `results/es/writing-session-012.md`). Use the `results_dir` from `read-db.py` computed output to locate the correct language subdirectory. This skill describes how to read those files to plan adaptive follow-up practice. Use it when the tutor needs narrative context the JSON databases don't capture — the exact sentence the learner wrote, the scenario, the feedback they received.
 
 ## When to Use
 
@@ -24,10 +24,10 @@ Skip this skill when aggregated JSON numbers are enough — prefer `read-db.py` 
 ### 1. Find recent session files
 
 ```
-/results/{skill}-session-{ID}.md
+{computed.results_dir}/{skill}-session-{ID}.md
 ```
 
-File naming: `{skill}-session-{NNN}.md` keeps files grouped by skill + chronological by ID. Read the most recent 3-5 files of the relevant skill; don't re-read the entire history.
+Use the `results_dir` value from `read-db.py` computed output — e.g. `results/es/` when `FLUENT_LANG=es`. File naming: `{skill}-session-{NNN}.md` keeps files grouped by skill + chronological by ID. Read the most recent 3-5 files of the relevant skill; don't re-read the entire history.
 
 ### 2. Extract error patterns
 
@@ -132,9 +132,9 @@ Trend: accuracy rising ~7% per session. Critical errors halving each session —
 
 ## Critical Rules
 
-- **Read `/results/` markdown for context.** Use `read-db.py` for numerical summaries — don't reimplement counts by re-parsing markdown when the DB already has them.
+- **Read `{computed.results_dir}/` markdown for context.** Use `read-db.py` for numerical summaries — don't reimplement counts by re-parsing markdown when the DB already has them.
 - **Cap the look-back window.** 3-5 recent sessions for the relevant skill. Older data is already baked into `mistakes-db.json` mastery levels.
-- **Never alter `/results/` files.** They are immutable records. Planning only.
+- **Never alter session files.** They are immutable records. Planning only.
 
 ## Why This Matters
 

--- a/.claude/skills/fluent-speaking/SKILL.md
+++ b/.claude/skills/fluent-speaking/SKILL.md
@@ -165,7 +165,7 @@ Use the `fluent-db-updater` skill:
 - `errors[]` — only communication-blocking ones (don't flood mistakes-db with minor speaking slips)
 - `focus_next_session[]` — one topic + one pattern
 
-Save exchange to `/results/fluent-speaking-session-{NNN}.md`.
+Save exchange to `{computed.results_dir}/fluent-speaking-session-{NNN}.md` (use the `results_dir` value from the `read-db.py` output).
 
 ## Examples
 

--- a/.claude/skills/fluent-writing/SKILL.md
+++ b/.claude/skills/fluent-writing/SKILL.md
@@ -153,7 +153,7 @@ Use the `fluent-db-updater` skill:
 - `errors[]` — one per distinct pattern found (dedupe; the script bumps frequency)
 - `focus_next_session[]` — top 2 patterns to drill
 
-Also save the exchange as `/results/fluent-writing-session-{NNN}.md` with the full task, the learner's original text, the corrected version, and the error table. The `fluent-session-analyzer` skill depends on this format.
+Also save the exchange as `{computed.results_dir}/fluent-writing-session-{NNN}.md` with the full task, the learner's original text, the corrected version, and the error table. The `fluent-session-analyzer` skill depends on this format.
 
 ## Examples
 
@@ -216,7 +216,7 @@ Learner: "Hallo, Ik schrijf je omdat ik kan niet komen op donderdag. Ik ben ziek
 - **One scenario per session.** Don't chain multiple writing tasks — depth over breadth.
 - **Wait for the full answer** before correcting.
 - **Severity tagging is mandatory.** Fed into `mistakes-db` and drives spaced repetition priority.
-- **Always save the session file** in `/results/` for later analysis by `fluent-session-analyzer`.
+- **Always save the session file** in `{computed.results_dir}/` for later analysis by `fluent-session-analyzer`.
 - **Never auto-invoke.** This skill is gated; must fire only on explicit `/fluent-writing`.
 
 ## Language Reference

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,8 +62,9 @@ When the learner uses these commands, follow their specific flows:
 - **/fluent-progress** - Show statistics, visualize progress
 - **/fluent-review** - Today's spaced repetition reviews
 - **/fluent-setup** - Interactive onboarding for new learners
+- **/fluent-lang** - Switch active study language mid-session (e.g. `/fluent-lang fr`)
 
-See `.claude/skills/` directory for detailed skill specifications. Each skill lives at `.claude/skills/<name>/SKILL.md` with YAML frontmatter. Learner-facing skills (`/fluent-setup`, `/fluent-learn`, `/fluent-vocab`, `/fluent-writing`, `/fluent-speaking`, `/fluent-reading`, `/fluent-review`) carry `disable-model-invocation: true` so they only fire when the learner types the slash command. `/fluent-progress` auto-invokes on stats questions. Helper skills (`fluent-sm2-calculator`, `fluent-feedback-formatter`, `fluent-db-updater`, `fluent-session-analyzer`) are also slash-invokable (no gating) and auto-load whenever Claude needs them during a session — they're visible in the slash menu so curious learners can open the reference directly.
+See `.claude/skills/` directory for detailed skill specifications. Each skill lives at `.claude/skills/<name>/SKILL.md` with YAML frontmatter. Learner-facing skills (`/fluent-setup`, `/fluent-learn`, `/fluent-vocab`, `/fluent-writing`, `/fluent-speaking`, `/fluent-reading`, `/fluent-review`, `/fluent-lang`) carry `disable-model-invocation: true` so they only fire when the learner types the slash command. `/fluent-progress` auto-invokes on stats questions. Helper skills (`fluent-sm2-calculator`, `fluent-feedback-formatter`, `fluent-db-updater`, `fluent-session-analyzer`) are also slash-invokable (no gating) and auto-load whenever Claude needs them during a session — they're visible in the slash menu so curious learners can open the reference directly.
 
 ## Learning Principles (Evidence-Based)
 

--- a/README.md
+++ b/README.md
@@ -67,11 +67,28 @@ Learner data lives in `./data/` inside the cloned repo instead of `~/.claude/flu
 Fluent resolves the data directory in this order — first match wins:
 
 1. `$FLUENT_DATA_DIR` if set (override everything).
-2. `$CLAUDE_PROJECT_DIR/data/` if it has `learner-profile.json` (clone mode, running from outside the repo root).
-3. `./data/` if it has `learner-profile.json` (clone mode, running inside the repo).
-4. `~/.claude/fluent-data/` (plugin-install default).
+2. `$CLAUDE_PROJECT_DIR/data/$FLUENT_LANG` if `FLUENT_LANG` is set (language subdirectory).
+3. `$CLAUDE_PROJECT_DIR/data/` if it has `learner-profile.json` (clone mode, running from outside the repo root).
+4. `./data/$FLUENT_LANG` if `FLUENT_LANG` is set (clone mode, in-repo cwd).
+5. `./data/` if it has `learner-profile.json` (clone mode, running inside the repo).
+6. `~/.claude/fluent-data/$FLUENT_LANG` if `FLUENT_LANG` is set (plugin-mode).
+7. `~/.claude/fluent-data/` (plugin-install default).
 
-Set `FLUENT_DATA_DIR` to run multiple learners on one machine:
+### Studying multiple languages
+
+Set `FLUENT_LANG` to a language code when launching Claude Code. Each language gets its own isolated data directory and results subdirectory — no data is ever mixed or overwritten.
+
+```bash
+# Spanish session  (data: ~/.claude/fluent-data/es/  results: results/es/)
+FLUENT_LANG=es claude
+
+# French session   (data: ~/.claude/fluent-data/fr/  results: results/fr/)
+FLUENT_LANG=fr claude
+```
+
+Run `/fluent-setup` once per language the first time to initialize the profile. After that, just launch with the appropriate `FLUENT_LANG` — the session-start hook will greet you in the right language with the correct stats.
+
+For a completely custom path, use the lower-level `FLUENT_DATA_DIR` override:
 
 ```bash
 export FLUENT_DATA_DIR=~/.fluent/dutch
@@ -80,7 +97,7 @@ export FLUENT_DATA_DIR=~/.fluent/dutch
 Check where Fluent is currently looking:
 
 ```bash
-python3 -c "import sys; sys.path.insert(0, '.claude/hooks'); from fluent_paths import data_dir; print(data_dir())"
+python3 -c "import sys; sys.path.insert(0, '.claude/hooks'); from fluent_paths import data_dir, results_dir; print('data:', data_dir()); print('results:', results_dir())"
 ```
 
 ---
@@ -185,12 +202,12 @@ This system implements proven learning science:
 
 ## 🎮 Available Commands & Skills
 
-Fluent is built as **Claude Code skills** — 12 of them. Skills work two ways:
+Fluent is built as **Claude Code skills** — 13 of them. Skills work two ways:
 
 1. **Type the slash command** (`/fluent-learn`, `/fluent-vocab`, etc.) — you explicitly start a session. Learner-facing skills are gated so they only run this way. No accidental 20-minute session triggered by a chat message.
 2. **Ask naturally** — read-only skills like `/fluent-progress` auto-trigger when you ask "how am I doing?" or "what's my streak?". Helper skills (SM-2 math, feedback formatter, DB updater, session analyzer) auto-load whenever Claude needs them during a session.
 
-All 12 skills appear in your `/` menu so you can always invoke any of them manually.
+All 13 skills appear in your `/` menu so you can always invoke any of them manually.
 
 ### Learner-facing commands
 
@@ -203,6 +220,7 @@ These are the commands you'll use daily. Each is backed by a dedicated skill und
 | **`/fluent-setup`** | **One-time onboarding** - Asks you questions about your name, target language, current level, goals, and timeline. Creates your personalized learning profile. | **First time only** - Run this once to set up your account. The system generates a custom learning plan based on your answers. |
 | **`/fluent-learn`** | **Adaptive mixed practice** - Combines different exercise types (vocabulary, grammar, sentences) based on your weak areas. Adjusts difficulty in real-time based on your performance. | **Daily core practice** - Your main command for general improvement. The AI decides what you need to practice most. Best after `/fluent-review`. |
 | **`/fluent-review`** | **Spaced repetition session** - Shows you items that are due for review today based on the SM-2 algorithm. Focuses on things you learned before that need reinforcement. | **Start every day here!** - Review before learning new content. This is scientifically proven to be the most effective way to retain what you've learned. |
+| **`/fluent-lang`** | **Language switcher** - Type `/fluent-lang fr` to switch to French, `/fluent-lang es` for Spanish, or any ISO 639-1 code. Also accepts full names ("switch to Japanese"). Type `/fluent-lang` alone to see your current language. Takes effect immediately — no restart needed. | **When studying multiple languages** - Run once per session to pick which language to practice. Run `/fluent-setup` the first time you add a new language to initialize its profile. |
 
 #### Skill-Specific Commands
 
@@ -284,7 +302,7 @@ The AI follows these guides:
 
 ### Interface Layer
 
-- **Skills** (`.claude/skills/`) — 12 skills total. 8 learner-facing (`/fluent-setup`, `/fluent-learn`, `/fluent-vocab`, `/fluent-writing`, `/fluent-speaking`, `/fluent-reading`, `/fluent-review`, `/fluent-progress`) run when you invoke them. 4 helper skills (`/fluent-sm2-calculator`, `/fluent-feedback-formatter`, `/fluent-db-updater`, `/fluent-session-analyzer`) auto-load whenever Claude needs them during a session — and are also directly `/`-invokable if you want to read the reference.
+- **Skills** (`.claude/skills/`) — 13 skills total. 9 learner-facing (`/fluent-setup`, `/fluent-learn`, `/fluent-vocab`, `/fluent-writing`, `/fluent-speaking`, `/fluent-reading`, `/fluent-review`, `/fluent-progress`, `/fluent-lang`) run when you invoke them. 4 helper skills (`/fluent-sm2-calculator`, `/fluent-feedback-formatter`, `/fluent-db-updater`, `/fluent-session-analyzer`) auto-load whenever Claude needs them during a session — and are also directly `/`-invokable if you want to read the reference.
 - **Plugin manifests** (`.claude-plugin/`) — `plugin.json` + `marketplace.json` make Fluent installable via `/plugin marketplace add m98/fluent`.
 - **Automatic Hooks** (`.claude/hooks/`) — SessionStart welcome, SessionEnd backups, PostToolUse JSON validation + backups, PreCompact safety backup. Both `hooks.json` (plugin mode) and `.claude/settings.json` (clone mode) wire them up.
 - **Session Results** (`/results/`) — Detailed practice logs per session, parsed by `fluent-session-analyzer` to plan future sessions.
@@ -444,7 +462,7 @@ It helps others discover this project and motivates us to keep improving it!
 
 ## 📈 Project Stats
 
-- **Skills:** 12 (8 learner-facing + 4 helper)
+- **Skills:** 13 (9 learner-facing + 4 helper)
 - **Hooks:** 5 automated (SessionStart, SessionEnd, PostToolUse, PreCompact, DB helpers)
 - **Databases:** 6 JSON tracking files
 - **Install paths:** 2 (Claude Code plugin + git clone — both supported)


### PR DESCRIPTION
## Description

Adds first-class multi-language support to Fluent, allowing learners to study multiple languages from the same install — each with fully isolated data, spaced-repetition queues, and session history.

Two complementary mechanisms:

1. **`FLUENT_LANG` environment variable** — set at launch time for language-specific sessions (e.g. `FLUENT_LANG=fr claude`). Each language resolves to its own subdirectory (`~/.claude/fluent-data/fr/` in plugin mode, `./data/fr/` in clone mode), fully backwards-compatible with existing single-language setups.

2. **`/fluent-lang` skill** — switch languages mid-session without restarting. Writes the active language code to `~/.claude/fluent-active-lang`, which every subsequent hook and skill call picks up automatically. Accepts ISO 639-1 codes (`/fluent-lang fr`) or natural language names ("switch to French", "quiero estudiar español"). Also shows the currently active language when invoked with no argument.

Session result files are now organized by language (`results/es/`, `results/fr/`) so histories never mix.

## Type of Change

- [x] New feature
- [x] Documentation update

## Changes

### Core infrastructure (`fluent_paths.py`)
- `_active_lang()` — reads `FLUENT_LANG` env var, falls back to `~/.claude/fluent-active-lang` config file
- `active_lang_file()` — returns path to the persisted language config
- `results_dir()` / `ensure_results_dir()` — language-namespaced results path
- Updated `data_dir()` with 7-level resolution precedence (adds language subdirectory tiers between existing levels, no breaking changes)

### `read-db.py`
- Adds `computed.results_dir` to output so skills receive the correct results path dynamically

### Practice skills (fluent-learn, writing, speaking, reading, review, session-analyzer)
- Replace hardcoded `/results/` paths with `{computed.results_dir}/` so each language's session markdown files stay in their own subdirectory

### New skill: `/fluent-lang`
- Gated with `disable-model-invocation: true` — only fires on explicit invocation
- Writes language code to `~/.claude/fluent-active-lang`
- Verifies switch via `read-db.py` and shows profile status (welcome back, or prompt to run `/fluent-setup` for new languages)

### Documentation
- `README.md`: add `/fluent-lang` to core commands table, update skill count 12→13, document `FLUENT_LANG` env var and multi-language workflow
- `CLAUDE.md`: add `/fluent-lang` to slash commands list

## Testing

- [x] Tested with multiple languages
- [x] All slash commands work
- [x] Data tracking verified
- [x] No regressions found

Verified path resolution for both `FLUENT_LANG=es` and `FLUENT_LANG=fr`, confirmed `computed.results_dir` in `read-db.py` output, and confirmed backwards compatibility (no env var → existing single-language behaviour unchanged).

## Checklist

- [x] Code follows style guidelines
- [x] Self-review completed
- [x] Documentation updated
- [x] No new warnings generated

## Additional Notes

Backwards compatibility is fully preserved: learners with an existing single-language setup and no `FLUENT_LANG` set will see zero change in behaviour. The new language directories are only created when `FLUENT_LANG` is set or `/fluent-lang` is invoked.