### PR TITLE
perf(hooks): output compact JSON from read-db.py instead of indent=2

### DIFF
--- a/.claude/hooks/read-db.py
+++ b/.claude/hooks/read-db.py
@@ -95,7 +95,7 @@ def main():
     if missing:
         result["_warnings"] = [f"Missing file: {m}" for m in missing]
 
-    json.dump(result, sys.stdout, indent=2, ensure_ascii=False)
+    json.dump(result, sys.stdout, separators=(",", ":"), ensure_ascii=False)
     print()
 
     sys.exit(1 if missing else 0)


### PR DESCRIPTION
## Summary

Every `/fluent-*` command dumps all 6 learner databases through `read-db.py` into the model's context. Pretty-printing with `indent=2` costs roughly a third of the payload in pure whitespace the model gains nothing from — it only needs the JSON parseable, not human-formatted.

Switching to `separators=(",", ":")` keeps the output byte-for-byte content-identical while cutting a real-world 404-item spaced-repetition payload from 444KB to 290KB (**-34.7%**). Smaller payload means less to tokenize before the model can respond, on every single Fluent command.

## Test plan

- [x] Ran both versions (`indent=2` vs `separators=(",", ":")`) against real learner data and confirmed `json.load(old) == json.load(new)` — content is unchanged, only formatting
- [x] Ran `/fluent-review` end-to-end afterward with no behavior change